### PR TITLE
Option to list branches with associated PR

### DIFF
--- a/GitPullRequest.Services.Tests/GitPullRequest.Services.Tests.csproj
+++ b/GitPullRequest.Services.Tests/GitPullRequest.Services.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -18,9 +18,9 @@ public class GitPullRequestServiceTests
             string expectUrl)
         {
             var repo = CreateRepository(originUrl,
-                "headSha", originName, upstreamBranchCanonicalName, new[]
+                "headSha", originName, upstreamBranchCanonicalName, new Dictionary<string, string>
                 {
-                    (referenceCanonicalName, "refSha")
+                    { referenceCanonicalName, "refSha" }
                 });
             var target = new GitPullRequestService();
             var gitHubRepositories = target.GetGitHubRepositories(repo);
@@ -50,7 +50,7 @@ public class GitPullRequestServiceTests
         [Test]
         public void NoPrs()
         {
-            var repo = CreateRepository("https://github.com/owner/repo", "sha", null, null, new (string, string)[0]);
+            var repo = CreateRepository("https://github.com/owner/repo", "sha", null, null, new Dictionary<string, string> { });
             var target = new GitPullRequestService();
             var gitHubRepositories = target.GetGitHubRepositories(repo);
 
@@ -65,10 +65,10 @@ public class GitPullRequestServiceTests
         {
             var number = 777;
             var repo = CreateRepository("https://github.com/owner/repo",
-                headSha, "origin", "refs/heads/one", new[]
+                headSha, "origin", "refs/heads/one", new Dictionary<string, string>
                 {
-                    ("refs/heads/one", prSha),
-                    ($"refs/pull/{number}/head", prSha)
+                    { "refs/heads/one", prSha },
+                    { $"refs/pull/{number}/head", prSha }
                 });
             var target = new GitPullRequestService();
             var gitHubRepositories = target.GetGitHubRepositories(repo);
@@ -82,7 +82,7 @@ public class GitPullRequestServiceTests
     static IRepository CreateRepository(
         string originUrl,
         string headSha, string remoteName, string upstreamBranchCanonicalName,
-        (string CanonicalName, string TargetIdentifier)[] refs)
+        IDictionary<string, string> refs)
     {
         var repo = Substitute.For<IRepository>();
         var remoteList = remoteName != null ? new Remote[] { CreateRemote(remoteName, originUrl) } : Array.Empty<Remote>();
@@ -126,13 +126,13 @@ public class GitPullRequestServiceTests
         return network;
     }
 
-    static void AddReferences(IRepository repository, Remote remote, (string CanonicalName, string TargetIdentifier)[] refs)
+    static void AddReferences(IRepository repository, Remote remote, IDictionary<string, string> refs)
     {
         var references = refs.Select(r =>
         {
             var reference = Substitute.For<Reference>();
-            reference.CanonicalName.Returns(r.CanonicalName);
-            reference.TargetIdentifier.Returns(r.TargetIdentifier);
+            reference.CanonicalName.Returns(r.Key);
+            reference.TargetIdentifier.Returns(r.Value);
             return reference;
         }).ToList();
 

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -54,7 +54,7 @@ public class GitPullRequestServiceTests
             var target = new GitPullRequestService();
             var gitHubRepositories = target.GetGitHubRepositories(repo);
 
-            var prs = target.FindPullRequests(gitHubRepositories, repo);
+            var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 
             Assert.That(prs, Is.Empty);
         }
@@ -73,7 +73,7 @@ public class GitPullRequestServiceTests
             var target = new GitPullRequestService();
             var gitHubRepositories = target.GetGitHubRepositories(repo);
 
-            var prs = target.FindPullRequests(gitHubRepositories, repo);
+            var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 
             Assert.That(prs.FirstOrDefault().Number, Is.EqualTo(number));
         }

--- a/GitPullRequest.Services/GitHubRepository.cs
+++ b/GitPullRequest.Services/GitHubRepository.cs
@@ -4,7 +4,8 @@ namespace GitPullRequest.Services
 {
     public class GitHubRepository
     {
-        public IDictionary<string, string> References { get; set; }
+        public string RemoteName { get; set; }
         public string Url { get; set; }
+        public IDictionary<string, string> References { get; set; }
     }
 }

--- a/GitPullRequest.Services/GitPullRequest.Services.csproj
+++ b/GitPullRequest.Services/GitPullRequest.Services.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -25,8 +25,9 @@ namespace GitPullRequest.Services
         {
             return new GitHubRepository
             {
-                References = GetReferences(repo, remoteName),
-                Url = GetRepositoryUrl(repo, remoteName)
+                RemoteName = remoteName,
+                Url = GetRepositoryUrl(repo, remoteName),
+                References = GetReferences(repo, remoteName)
             };
         }
 

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -31,10 +31,8 @@ namespace GitPullRequest.Services
         }
 
         public IList<(GitHubRepository Repository, int Number)> FindPullRequests(
-            IDictionary<string, GitHubRepository> gitHubRepositories, IRepository repo)
+            IDictionary<string, GitHubRepository> gitHubRepositories, Branch branch)
         {
-            var branch = repo.Head;
-
             string sha = null;
             if (branch.IsTracking)
             {

--- a/GitPullRequest/GitPullRequest.csproj
+++ b/GitPullRequest/GitPullRequest.csproj
@@ -10,12 +10,15 @@
 
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
+
+    <LangVersion>7.3</LangVersion>
 
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0-alpha" />
     <PackageReference Include="Microsoft.Alm.Authentication" Version="4.3.0" />
   </ItemGroup>
 

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -3,50 +3,95 @@ using System.IO;
 using System.Diagnostics;
 using LibGit2Sharp;
 using GitPullRequest.Services;
+using McMaster.Extensions.CommandLineUtils;
+using System.Linq;
 
 namespace GitPullRequest
 {
-    class Program
+    [Command(Name = "git-pr", Description = "Git extension to view pull requests")]
+    [HelpOption("-?")]
+    public class Program
     {
-        static void Main(string[] args)
+        public static int Main(string[] args)
+            => CommandLineApplication.Execute<Program>(args);
+
+        [Argument(0, Description = "The target git directory")]
+        public string TargetDir { get; } = Directory.GetCurrentDirectory();
+
+        [Option("--list", Description = "List local branches with associated pull requests")]
+        public bool List { get; }
+
+        void OnExecute()
         {
-            var targetDir = args.Length >= 1 ? args[0] : Directory.GetCurrentDirectory();
-            var repoPath = Repository.Discover(targetDir);
+            var repoPath = Repository.Discover(TargetDir);
             if (repoPath == null)
             {
                 Console.WriteLine("Couldn't find Git repository");
                 return;
             }
 
+            var service = new GitPullRequestService();
             using (var repo = new Repository(repoPath))
             {
-                var service = new GitPullRequestService();
-                var gitHubRepositories = service.GetGitHubRepositories(repo);
-                var prs = service.FindPullRequests(gitHubRepositories, repo);
-
-                if (prs.Count > 0)
+                if (List)
                 {
-                    foreach (var pr in prs)
-                    {
-                        var prUrl = service.GetPullRequestUrl(pr.Repository, pr.Number);
-                        Browse(prUrl);
-                    }
-
+                    ListBranches(service, repo);
                     return;
                 }
 
-                var compareUrl = service.FindCompareUrl(gitHubRepositories, repo);
-                if (compareUrl != null)
-                {
-                    Browse(compareUrl);
-                    return;
-                }
-
-                Console.WriteLine("Couldn't find pull request or remote branch");
+                BrowsePullRequest(service, repo);
             }
         }
 
-        static void Browse(string pullUrl)
+        void BrowsePullRequest(GitPullRequestService service, Repository repo)
+        {
+            var gitHubRepositories = service.GetGitHubRepositories(repo);
+            var prs = service.FindPullRequests(gitHubRepositories, repo.Head);
+
+            if (prs.Count > 0)
+            {
+                foreach (var pr in prs)
+                {
+                    var prUrl = service.GetPullRequestUrl(pr.Repository, pr.Number);
+                    Browse(prUrl);
+                }
+
+                return;
+            }
+
+            var compareUrl = service.FindCompareUrl(gitHubRepositories, repo);
+            if (compareUrl != null)
+            {
+                Browse(compareUrl);
+                return;
+            }
+
+            Console.WriteLine("Couldn't find pull request or remote branch");
+        }
+
+        void ListBranches(GitPullRequestService service, Repository repo)
+        {
+            var gitHubRepositories = service.GetGitHubRepositories(repo);
+            foreach (var branch in repo.Branches)
+            {
+                if (branch.IsRemote)
+                {
+                    continue;
+                }
+
+                var prs = service.FindPullRequests(gitHubRepositories, branch);
+                var pr = prs.FirstOrDefault();
+                if (pr == default)
+                {
+                    continue;
+                }
+
+                var remotePostfix = branch.RemoteName != "origin" ? $" ({branch.RemoteName})" : "";
+                Console.WriteLine($"#{pr.Number} {branch.FriendlyName}{remotePostfix}");
+            }
+        }
+
+        void Browse(string pullUrl)
         {
             Process.Start(new ProcessStartInfo
             {

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -86,8 +86,9 @@ namespace GitPullRequest
                     continue;
                 }
 
+                var remotePrefix = pr.Repository.RemoteName != "origin" ? pr.Repository.RemoteName : "";
                 var remotePostfix = branch.RemoteName != "origin" ? $" ({branch.RemoteName})" : "";
-                Console.WriteLine($"#{pr.Number} {branch.FriendlyName}{remotePostfix}");
+                Console.WriteLine($"{remotePrefix}#{pr.Number} {branch.FriendlyName}{remotePostfix}");
             }
         }
 


### PR DESCRIPTION
`git pr --list`

The output will appear like this:

```
#2060 feature/open-file-from-github
#2071 fixes/1849-build-against-net46
#2068 fixes/2062-package-ValueTuple
#2087 fixes/embed-interop-assemblies
#2055 refactor/remove-trackingcollection
#1992 devops/install-for-2015
#2011 devops/launch-2019-preview
#2017 feature/pr-conversation
```

If a pull request originates from a remote that isn't called `origin`, the remote name will appear in brackets after the branch name:

```
#1667 pr/1667--wip-add-pull-request-filter-button-to-visual-studio-solution-explorer (laurentkempe)
#1984 pr/1984-adding-c-preferences-to-editorconfig (Neme12)
```

If a pull request targets a remote repository that isn't `origin`, the target remote name will be prefixed to the pull request number:

```
upstream#1667 fixes/bug
jcansdale#1984 fancy-feature
```
