### PR TITLE
Allow filtering by pull request number

### DIFF
--- a/GitPullRequest/GitPullRequest.csproj
+++ b/GitPullRequest/GitPullRequest.csproj
@@ -10,7 +10,7 @@
 
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
 
     <LangVersion>7.3</LangVersion>
 


### PR DESCRIPTION
### What this PR does

Passing a number is supported when browsing or listing a pull request.

Browse pull request 7:
```
git pr 7
```

Show branch for pull request 7:
```
git pr --list 7
```