### PR TITLE
Add --all option to list pull requests a local or remote branch

### DIFF
--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -24,6 +24,9 @@ namespace GitPullRequest
         [Option("--list", Description = "List local branches with associated pull requests")]
         public bool List { get; }
 
+        [Option("--all", Description = "List all branches with associated pull requests")]
+        public bool All { get; }
+
         void OnExecute()
         {
             var repoPath = Repository.Discover(TargetDir);
@@ -36,7 +39,7 @@ namespace GitPullRequest
             var service = new GitPullRequestService();
             using (var repo = new Repository(repoPath))
             {
-                if (List)
+                if (List || All)
                 {
                     ListBranches(service, repo);
                     return;
@@ -86,7 +89,7 @@ namespace GitPullRequest
         {
             var gitHubRepositories = service.GetGitHubRepositories(repo);
             var prs = repo.Branches
-                .Where(b => !b.IsRemote)
+                .Where(b => All || !b.IsRemote)
                 .SelectMany(b => service.FindPullRequests(gitHubRepositories, b), (b, p) => (Branch: b, PullRequest: p))
                 .Where(bp => PullRequestNumber == 0 || bp.PullRequest.Number == PullRequestNumber)
                 .ToList();

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -55,7 +55,6 @@ namespace GitPullRequest
 
             var prs = (PullRequestNumber == 0 ? service.FindPullRequests(gitHubRepositories, repo.Head) :
                 repo.Branches
-                    .Where(b => !b.IsRemote)
                     .SelectMany(b => service.FindPullRequests(gitHubRepositories, b))
                     .Where(pr => pr.Number == PullRequestNumber)).ToList();
 

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -91,6 +91,8 @@ namespace GitPullRequest
                 .Where(b => All || !b.IsRemote)
                 .SelectMany(b => service.FindPullRequests(gitHubRepositories, b), (b, p) => (Branch: b, PullRequest: p))
                 .Where(bp => PullRequestNumber == 0 || bp.PullRequest.Number == PullRequestNumber)
+                .OrderBy(bp => bp.Branch.IsRemote)
+                .ThenBy(bp => bp.PullRequest.Number)
                 .ToList();
 
             if (prs.Count == 0)


### PR DESCRIPTION
The following command will list all pull requests with local or remote branches.
```
git pr --all
```

This is conceptually similar to `git branch --all` (which lists local and remote branches).

Pull requests without a local or remote branch won't be shows (e.g if a pull request has been closed and its associated branch deleted). In this case the only information we'd have about the pull request would be its number (which wouldn't be terribly useful).