### PR TITLE
Indicate current repository head with *

### DIFF
--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -105,9 +105,10 @@ namespace GitPullRequest
 
             foreach (var bp in prs)
             {
+                var isHead = bp.Branch.IsCurrentRepositoryHead ? "* " : "  ";
                 var remotePrefix = bp.PullRequest.Repository.RemoteName != "origin" ? bp.PullRequest.Repository.RemoteName : "";
                 var remotePostfix = bp.Branch.RemoteName != "origin" ? $" ({bp.Branch.RemoteName})" : "";
-                Console.WriteLine($"{remotePrefix}#{bp.PullRequest.Number} {bp.Branch.FriendlyName}{remotePostfix}");
+                Console.WriteLine($"{isHead}{remotePrefix}#{bp.PullRequest.Number} {bp.Branch.FriendlyName}{remotePostfix}");
             }
         }
 


### PR DESCRIPTION
Indicate the current branch with a `*` similar to `git branch`.

```
> git --list

  #1 feature/compare-when-no-pr
  #2 feature/support-multiple-remotes
  #3 feature/git-pr-list
  #5 feature/filter-pr-number
  #6 feature/option-to-list-all-prs
* #7 feature/show-head-branch
```