### PR TITLE
Mark deleted remote branches with an x

### DIFF
--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -111,8 +111,14 @@ namespace GitPullRequest
             {
                 var isHead = bp.Branch.IsCurrentRepositoryHead ? "* " : "  ";
                 var remotePrefix = bp.PullRequest.Repository.RemoteName != "origin" ? bp.PullRequest.Repository.RemoteName : "";
-                var remotePostfix = bp.Branch.RemoteName != "origin" ? $" ({bp.Branch.RemoteName})" : "";
-                Console.WriteLine($"{isHead}{remotePrefix}#{bp.PullRequest.Number} {bp.Branch.FriendlyName}{remotePostfix}");
+
+                var postfix = bp.PullRequest.IsDeleted ? "x " : "" + bp.Branch.RemoteName != "origin" ? bp.Branch.RemoteName : "";
+                if (postfix.Length > 0)
+                {
+                    postfix = $" ({postfix.TrimEnd()})";
+                }
+
+                Console.WriteLine($"{isHead}{remotePrefix}#{bp.PullRequest.Number} {bp.Branch.FriendlyName}{postfix}");
             }
         }
 


### PR DESCRIPTION
Pull request with a deleted remote branch will appear like this:
```
  #2059 refactor/set-active-repository
  #2066 fixes/2062-wrong-ValueTuple-reference
  #2068 fixes/2062-package-ValueTuple (x)
  #2071 fixes/1849-build-against-net46 (x)
```