### PR TITLE
Don't throw if we can't open browser

### DIFF
--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Diagnostics;
+using System.ComponentModel;
 using LibGit2Sharp;
 using GitPullRequest.Services;
 using McMaster.Extensions.CommandLineUtils;
-using System.Linq;
 
 namespace GitPullRequest
 {
@@ -71,7 +72,9 @@ namespace GitPullRequest
             {
                 foreach (var pr in prs)
                 {
-                    Browse(service.GetPullRequestUrl(pr.Repository, pr.Number));
+                    var url = service.GetPullRequestUrl(pr.Repository, pr.Number);
+                    Console.WriteLine(url);
+                    TryBrowse(url);
                 }
 
                 return;
@@ -86,7 +89,8 @@ namespace GitPullRequest
             var compareUrl = service.FindCompareUrl(gitHubRepositories, repo);
             if (compareUrl != null)
             {
-                Browse(compareUrl);
+                Console.WriteLine(compareUrl);
+                TryBrowse(compareUrl);
                 return;
             }
 
@@ -161,13 +165,22 @@ namespace GitPullRequest
             }
         }
 
-        void Browse(string pullUrl)
+        bool TryBrowse(string url)
         {
-            Process.Start(new ProcessStartInfo
+            try
             {
-                FileName = pullUrl,
-                UseShellExecute = true
-            });
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                });
+
+                return false;
+            }
+            catch (Win32Exception)
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Output URLs so user can copy/paste if browse doesn't work.

Fixes #13 

My Bash for Windows it was throwing  `System.ComponentModel.Win32Exception: No such file or directory`.  This was because I didn't have the `xdg-open` installed (see PowerShell/PowerShell#7198). This PR will make it output the URL and silently fail, allowing the use the copy/paste URL into their Windows browser.