### PR TITLE
Added support for Azure DevOps repositories

### DIFF
--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -24,7 +24,7 @@ public class GitPullRequestServiceTests
             {
                 AddRemoteReferences(repo, remote, new Dictionary<string, string> { { referenceCanonicalName, "refSha" } });
             }
-            var target = new GitPullRequestService();
+            GitPullRequestService target = CreateGitPullRequestService();
             var gitHubRepositories = target.GetGitRepositories(repo);
 
             var compareUrl = target.FindCompareUrl(gitHubRepositories, repo);
@@ -39,7 +39,7 @@ public class GitPullRequestServiceTests
         public void No_Pull_Request()
         {
             var repo = CreateRepository("sha", null, null, Array.Empty<Remote>());
-            var target = new GitPullRequestService();
+            var target = CreateGitPullRequestService();
             var gitHubRepositories = target.GetGitRepositories(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
@@ -61,7 +61,7 @@ public class GitPullRequestServiceTests
                     { "refs/heads/one", prSha },
                     { $"refs/pull/{number}/head", prSha }
                 });
-            var target = new GitPullRequestService();
+            var target = CreateGitPullRequestService();
             var gitHubRepositories = target.GetGitRepositories(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
@@ -85,7 +85,7 @@ public class GitPullRequestServiceTests
             var repo = CreateRepository(prSha, "origin", "refs/heads/one", new[] { originRemote, upstreamRemote });
             AddRemoteReferences(repo, originRemote, new Dictionary<string, string> { { "refs/heads/one", prSha } });
             AddRemoteReferences(repo, upstreamRemote, new Dictionary<string, string> { { $"refs/pull/{number}/head", prSha } });
-            var target = new GitPullRequestService();
+            var target = CreateGitPullRequestService();
             var gitHubRepositories = target.GetGitRepositories(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
@@ -95,6 +95,12 @@ public class GitPullRequestServiceTests
             Assert.That(pr.Repository.RemoteName, Is.EqualTo(upstreamRemoteName));
             Assert.That(pr.Number, Is.EqualTo(number));
         }
+    }
+
+    static GitPullRequestService CreateGitPullRequestService()
+    {
+        var gitService = new GitService();
+        return new GitPullRequestService(gitService);
     }
 
     static IRepository CreateRepository(

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -25,25 +25,11 @@ public class GitPullRequestServiceTests
                 AddRemoteReferences(repo, remote, new Dictionary<string, string> { { referenceCanonicalName, "refSha" } });
             }
             var target = new GitPullRequestService();
-            var gitHubRepositories = target.GetGitHubRepositories(repo);
+            var gitHubRepositories = target.GetGitRepositories(repo);
 
             var compareUrl = target.FindCompareUrl(gitHubRepositories, repo);
 
             Assert.That(compareUrl, Is.EqualTo(expectUrl));
-        }
-    }
-
-    public class TheGetPullRequestUrlMethod
-    {
-        [TestCase("https://github.com/owner/repo", 777, "https://github.com/owner/repo/pull/777")]
-        public void GetPullRequestUrl(string url, int number, string expectUrl)
-        {
-            var gitHubRepository = new GitHubRepository { Url = url };
-            var target = new GitPullRequestService();
-
-            var pullRequestUrl = target.GetPullRequestUrl(gitHubRepository, number);
-
-            Assert.That(pullRequestUrl, Is.EqualTo(expectUrl));
         }
     }
 
@@ -54,7 +40,7 @@ public class GitPullRequestServiceTests
         {
             var repo = CreateRepository("sha", null, null, Array.Empty<Remote>());
             var target = new GitPullRequestService();
-            var gitHubRepositories = target.GetGitHubRepositories(repo);
+            var gitHubRepositories = target.GetGitRepositories(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 
@@ -76,7 +62,7 @@ public class GitPullRequestServiceTests
                     { $"refs/pull/{number}/head", prSha }
                 });
             var target = new GitPullRequestService();
-            var gitHubRepositories = target.GetGitHubRepositories(repo);
+            var gitHubRepositories = target.GetGitRepositories(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 
@@ -100,7 +86,7 @@ public class GitPullRequestServiceTests
             AddRemoteReferences(repo, originRemote, new Dictionary<string, string> { { "refs/heads/one", prSha } });
             AddRemoteReferences(repo, upstreamRemote, new Dictionary<string, string> { { $"refs/pull/{number}/head", prSha } });
             var target = new GitPullRequestService();
-            var gitHubRepositories = target.GetGitHubRepositories(repo);
+            var gitHubRepositories = target.GetGitRepositories(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 

--- a/GitPullRequest.Services/AzureDevOpsRepository.cs
+++ b/GitPullRequest.Services/AzureDevOpsRepository.cs
@@ -8,12 +8,9 @@ namespace GitPullRequest.Services
 {
     internal class AzureDevOpsRepository : RemoteRepository
     {
-        readonly GitService gitService;
-
         public AzureDevOpsRepository(GitService gitService, IRepository repo, string remoteName)
             : base(gitService, repo, remoteName)
         {
-            this.gitService = gitService;
         }
 
         public override int FindPullRequestForCanonicalName(string canonicalName)
@@ -30,7 +27,7 @@ namespace GitPullRequest.Services
         protected override IDictionary<string, string> GetReferences(IRepository repo, string remoteName)
         {
             // for Azure DevOps we need to fetch PR branches so we can explore their history and get the commit before the automatic merge commit that is done on the server
-            gitService.Fetch(repo, remoteName, $"+refs/pull/*/merge:refs/remotes/{remoteName}/pull/*/merge");
+            GitService.Fetch(repo, remoteName, $"+refs/pull/*/merge:refs/remotes/{remoteName}/pull/*/merge");
 
             return base.GetReferences(repo, remoteName);
         }

--- a/GitPullRequest.Services/AzureDevOpsRepository.cs
+++ b/GitPullRequest.Services/AzureDevOpsRepository.cs
@@ -30,7 +30,7 @@ namespace GitPullRequest.Services
         protected override IDictionary<string, string> GetReferences(IRepository repo, string remoteName)
         {
             // for Azure DevOps we need to fetch PR branches so we can explore their history and get the commit before the automatic merge commit that is done on the server
-            gitService.Fetch(repo, remoteName, "+refs/pull/*/merge:refs/remotes/origin/pull/*/merge");
+            gitService.Fetch(repo, remoteName, $"+refs/pull/*/merge:refs/remotes/{remoteName}/pull/*/merge");
 
             return base.GetReferences(repo, remoteName);
         }

--- a/GitPullRequest.Services/AzureDevOpsRepository.cs
+++ b/GitPullRequest.Services/AzureDevOpsRepository.cs
@@ -6,9 +6,8 @@ using LibGit2Sharp.Handlers;
 
 namespace GitPullRequest.Services
 {
-    internal class AzureDevOpsRepository : GitRepository
+    internal class AzureDevOpsRepository : RemoteRepository
     {
-
         public AzureDevOpsRepository(IRepository repo, string remoteName)
             : base(repo, remoteName)
         {
@@ -25,33 +24,22 @@ namespace GitPullRequest.Services
             return -1;
         }
 
-        protected override string GetTipForReference(IRepository repo, Reference reference, CredentialsHandler credentialsHandler)
+        protected override string GetTipForReference(IRepository repo, Reference reference)
         {
-            // Sadly for Azure DevOps there is an automatic merge commit that is at the tip of the ref, so we have to fetch it, in order to find the previous commit
-            // as that is what the users branch will be up to
             if (reference.CanonicalName.StartsWith("refs/pull/", StringComparison.OrdinalIgnoreCase))
             {
-                Commit commit;
-                try
+                // Sadly for Azure DevOps there is an automatic merge commit that is at the tip of the ref, so we have to fetch it, in order to find the previous commit
+                // as that is what the users branch will be up to
+                if (repo.Lookup<Commit>(reference.TargetIdentifier) == null)
                 {
-                    commit = GetCommit();
+                    repo.Network.Fetch(this.RemoteName, new string[] { reference.CanonicalName }, new FetchOptions { CredentialsProvider = CreateCredentialsHandler() });
                 }
-                catch
-                {
-                    // Try again, but this time lets fetch the specific commit and see if that helps
-                    repo.Network.Fetch(this.RemoteName, new string[] { reference.CanonicalName }, new FetchOptions { CredentialsProvider = credentialsHandler });
-                    commit = GetCommit();
-                }
+                // Get the commit at HEAD^1
+                var commit = repo.Commits.QueryBy(new CommitFilter() { IncludeReachableFrom = reference.TargetIdentifier }).Skip(1).FirstOrDefault();
                 return commit.Sha;
             }
             return reference.TargetIdentifier;
-
-            Commit GetCommit()
-            {
-                return repo.Commits.QueryBy(new CommitFilter() { IncludeReachableFrom = reference.TargetIdentifier }).Skip(1).FirstOrDefault();
-            }
         }
-
 
         public override string GetPullRequestUrl(int number)
         {

--- a/GitPullRequest.Services/AzureDevOpsRepository.cs
+++ b/GitPullRequest.Services/AzureDevOpsRepository.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using LibGit2Sharp;
+using LibGit2Sharp.Handlers;
+
+namespace GitPullRequest.Services
+{
+    internal class AzureDevOpsRepository : GitRepository
+    {
+
+        public AzureDevOpsRepository(IRepository repo, string remoteName)
+            : base(repo, remoteName)
+        {
+        }
+
+        public override int FindPullRequestForCanonicalName(string canonicalName)
+        {
+            var match = Regex.Match(canonicalName, "^refs/pull/([0-9]+)/merge$");
+            if (match.Success && int.TryParse(match.Groups[1].Value, out int number))
+            {
+                return number;
+            }
+
+            return -1;
+        }
+
+        protected override string GetTipForReference(IRepository repo, Reference reference, CredentialsHandler credentialsHandler)
+        {
+            // Sadly for Azure DevOps there is an automatic merge commit that is at the tip of the ref, so we have to fetch it, in order to find the previous commit
+            // as that is what the users branch will be up to
+            if (reference.CanonicalName.StartsWith("refs/pull/", StringComparison.OrdinalIgnoreCase))
+            {
+                Commit commit;
+                try
+                {
+                    commit = GetCommit();
+                }
+                catch
+                {
+                    // Try again, but this time lets fetch the specific commit and see if that helps
+                    repo.Network.Fetch(this.RemoteName, new string[] { reference.CanonicalName }, new FetchOptions { CredentialsProvider = credentialsHandler });
+                    commit = GetCommit();
+                }
+                return commit.Sha;
+            }
+            return reference.TargetIdentifier;
+
+            Commit GetCommit()
+            {
+                return repo.Commits.QueryBy(new CommitFilter() { IncludeReachableFrom = reference.TargetIdentifier }).Skip(1).FirstOrDefault();
+            }
+        }
+
+
+        public override string GetPullRequestUrl(int number)
+        {
+            return $"{Url}/pullrequest/{number}";
+        }
+
+        public override string GetCompareUrl(string friendlyBranchName)
+        {
+            return $"{Url}/pullrequestcreate?sourceRef={Uri.EscapeUriString(friendlyBranchName)}";
+        }
+    }
+}

--- a/GitPullRequest.Services/GitHubRepository.cs
+++ b/GitPullRequest.Services/GitHubRepository.cs
@@ -5,8 +5,8 @@ namespace GitPullRequest.Services
 {
     internal class GitHubRepository : RemoteRepository
     {
-        public GitHubRepository(IRepository repo, string remoteName)
-            : base(repo, remoteName)
+        public GitHubRepository(GitService gitService, IRepository repo, string remoteName)
+            : base(gitService, repo, remoteName)
         {
         }
 

--- a/GitPullRequest.Services/GitHubRepository.cs
+++ b/GitPullRequest.Services/GitHubRepository.cs
@@ -1,17 +1,16 @@
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using LibGit2Sharp;
 
 namespace GitPullRequest.Services
 {
-    internal class GitHubRepository : GitRepository
+    internal class GitHubRepository : RemoteRepository
     {
         public GitHubRepository(IRepository repo, string remoteName)
             : base(repo, remoteName)
         {
         }
 
-        public override string GetRepositoryUrl(IRepository repo, string remoteName)
+        protected override string GetRepositoryUrl(IRepository repo, string remoteName)
         {
             var url = base.GetRepositoryUrl(repo, remoteName);
             var postfix = ".git";

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -10,9 +10,9 @@ namespace GitPullRequest.Services
 {
     public class GitPullRequestService
     {
-        public IDictionary<string, GitRepository> GetGitRepositories(IRepository repo)
+        public IDictionary<string, RemoteRepository> GetGitRepositories(IRepository repo)
         {
-            var gitRepositories = new Dictionary<string, GitRepository>();
+            var gitRepositories = new Dictionary<string, RemoteRepository>();
             foreach (var remote in repo.Network.Remotes)
             {
                 var remoteName = remote.Name;
@@ -22,8 +22,8 @@ namespace GitPullRequest.Services
             return gitRepositories;
         }
 
-        public IList<(GitRepository Repository, int Number, bool IsDeleted)> FindPullRequests(
-            IDictionary<string, GitRepository> gitRepositories, Branch branch)
+        public IList<(RemoteRepository Repository, int Number, bool IsDeleted)> FindPullRequests(
+            IDictionary<string, RemoteRepository> gitRepositories, Branch branch)
         {
             var isDeleted = false;
             string sha = null;
@@ -43,8 +43,8 @@ namespace GitPullRequest.Services
                 .Select(pr => (pr.Repository, pr.Number, isDeleted)).ToList();
         }
 
-        public IList<(GitRepository Repository, int Number)> FindPullRequestsForSha(
-            IDictionary<string, GitRepository> gitRepositories, string sha)
+        public IList<(RemoteRepository Repository, int Number)> FindPullRequestsForSha(
+            IDictionary<string, RemoteRepository> gitRepositories, string sha)
         {
             return gitRepositories
                 .SelectMany(r => r.Value.References, (x, y) => (Repository: x.Value, Reference: y))
@@ -53,7 +53,7 @@ namespace GitPullRequest.Services
                 .ToList();
         }
 
-        public string FindCompareUrl(IDictionary<string, GitRepository> gitRepositories, IRepository repo)
+        public string FindCompareUrl(IDictionary<string, RemoteRepository> gitRepositories, IRepository repo)
         {
             var branch = repo.Head;
             if (!branch.IsTracking)

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -4,42 +4,33 @@ using System.Text.RegularExpressions;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 using Microsoft.Alm.Authentication;
+using System;
 
 namespace GitPullRequest.Services
 {
     public class GitPullRequestService
     {
-        public IDictionary<string, GitHubRepository> GetGitHubRepositories(IRepository repo)
+        public IDictionary<string, GitRepository> GetGitRepositories(IRepository repo)
         {
-            var gitHubRepositories = new Dictionary<string, GitHubRepository>();
+            var gitRepositories = new Dictionary<string, GitRepository>();
             foreach (var remote in repo.Network.Remotes)
             {
                 var remoteName = remote.Name;
-                gitHubRepositories[remoteName] = GetGitHubRepository(repo, remoteName);
+                gitRepositories[remoteName] = GitRepositoryFactory.Create(repo, remoteName);
             }
 
-            return gitHubRepositories;
+            return gitRepositories;
         }
 
-        public GitHubRepository GetGitHubRepository(IRepository repo, string remoteName)
-        {
-            return new GitHubRepository
-            {
-                RemoteName = remoteName,
-                Url = GetRepositoryUrl(repo, remoteName),
-                References = GetReferences(repo, remoteName)
-            };
-        }
-
-        public IList<(GitHubRepository Repository, int Number, bool IsDeleted)> FindPullRequests(
-            IDictionary<string, GitHubRepository> gitHubRepositories, Branch branch)
+        public IList<(GitRepository Repository, int Number, bool IsDeleted)> FindPullRequests(
+            IDictionary<string, GitRepository> gitRepositories, Branch branch)
         {
             var isDeleted = false;
             string sha = null;
             if (branch.IsTracking)
             {
-                var gitHubRepository = gitHubRepositories[branch.RemoteName];
-                var references = gitHubRepository.References;
+                var gitRepository = gitRepositories[branch.RemoteName];
+                var references = gitRepository.References;
                 isDeleted = !references.TryGetValue(branch.UpstreamBranchCanonicalName, out sha);
             }
 
@@ -48,27 +39,21 @@ namespace GitPullRequest.Services
                 sha = branch.Tip.Sha;
             }
 
-            return FindPullRequestsForSha(gitHubRepositories, sha)
+            return FindPullRequestsForSha(gitRepositories, sha)
                 .Select(pr => (pr.Repository, pr.Number, isDeleted)).ToList();
         }
 
-        public IList<(GitHubRepository Repository, int Number)> FindPullRequestsForSha(
-            IDictionary<string, GitHubRepository> gitHubRepositories, string sha)
+        public IList<(GitRepository Repository, int Number)> FindPullRequestsForSha(
+            IDictionary<string, GitRepository> gitRepositories, string sha)
         {
-            return gitHubRepositories
+            return gitRepositories
                 .SelectMany(r => r.Value.References, (x, y) => (Repository: x.Value, Reference: y))
-                .Where(kv => kv.Reference.Value == sha)
-                .Select(kv => (kv.Repository, Number: FindPullRequestForCanonicalName(kv.Reference.Key)))
+                .Where(kv => kv.Reference.Value == sha).Select(kv => (kv.Repository, Number: kv.Repository.FindPullRequestForCanonicalName(kv.Reference.Key)))
                 .Where(pr => pr.Number != -1)
                 .ToList();
         }
 
-        public string GetPullRequestUrl(GitHubRepository gitHubRepository, int number)
-        {
-            return $"{gitHubRepository.Url}/pull/{number}";
-        }
-
-        public string FindCompareUrl(IDictionary<string, GitHubRepository> gitHubRepositories, IRepository repo)
+        public string FindCompareUrl(IDictionary<string, GitRepository> gitRepositories, IRepository repo)
         {
             var branch = repo.Head;
             if (!branch.IsTracking)
@@ -77,14 +62,14 @@ namespace GitPullRequest.Services
             }
 
             var upstreamBranchCanonicalName = branch.UpstreamBranchCanonicalName;
-            var gitHubRepository = gitHubRepositories[branch.RemoteName];
-            if (!gitHubRepository.References.ContainsKey(upstreamBranchCanonicalName))
+            var gitRepository = gitRepositories[branch.RemoteName];
+            if (!gitRepository.References.ContainsKey(upstreamBranchCanonicalName))
             {
                 return null;
             }
 
             var friendlyName = GetFriendlyName(upstreamBranchCanonicalName);
-            return $"{gitHubRepository.Url}/compare/{friendlyName}";
+            return gitRepository.GetCompareUrl(friendlyName);
         }
 
         static string GetFriendlyName(string canonicalName)
@@ -96,53 +81,6 @@ namespace GitPullRequest.Services
             }
 
             return canonicalName.Substring(prefix.Length);
-        }
-
-        static int FindPullRequestForCanonicalName(string canonicalName)
-        {
-            var match = Regex.Match(canonicalName, "^refs/pull/([0-9]+)/head$");
-            if (match.Success && int.TryParse(match.Groups[1].Value, out int number))
-            {
-                return number;
-            }
-
-            return -1;
-        }
-
-        static string GetRepositoryUrl(IRepository repo, string remoteName)
-        {
-            var url = repo.Network.Remotes[remoteName].Url;
-            var postfix = ".git";
-            if (url.EndsWith(postfix))
-            {
-                url = url.Substring(0, url.Length - postfix.Length);
-            }
-
-            return url;
-        }
-
-        static IDictionary<string, string> GetReferences(IRepository repo, string remoteName)
-        {
-            var secrets = new SecretStore("git");
-            var auth = new BasicAuthentication(secrets);
-            var creds = auth.GetCredentials(new TargetUri("https://github.com"));
-
-            CredentialsHandler credentialsHandler =
-                (url, user, cred) => new UsernamePasswordCredentials
-                {
-                    Username = creds.Username,
-                    Password = creds.Password
-                };
-
-            var dictionary = new Dictionary<string, string>();
-            var remote = repo.Network.Remotes[remoteName];
-            var refs = repo.Network.ListReferences(remote, credentialsHandler);
-            foreach (var reference in refs)
-            {
-                dictionary[reference.CanonicalName] = reference.TargetIdentifier;
-            }
-
-            return dictionary;
         }
     }
 }

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -19,7 +19,13 @@ namespace GitPullRequest.Services
             foreach (var remote in repo.Network.Remotes)
             {
                 var remoteName = remote.Name;
-                gitRepositories[remoteName] = GitRepositoryFactory.Create(gitService, repo, remoteName);
+                var hostedRepository = GitRepositoryFactory.Create(gitService, repo, remote.Name);
+                if (hostedRepository == null)
+                {
+                    continue;
+                }
+
+                gitRepositories[remoteName] = hostedRepository;
             }
 
             return gitRepositories;

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -1,22 +1,25 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using LibGit2Sharp;
-using LibGit2Sharp.Handlers;
-using Microsoft.Alm.Authentication;
-using System;
 
 namespace GitPullRequest.Services
 {
     public class GitPullRequestService
     {
+        readonly GitService gitService;
+
+        public GitPullRequestService(GitService gitService)
+        {
+            this.gitService = gitService;
+        }
+
         public IDictionary<string, RemoteRepository> GetGitRepositories(IRepository repo)
         {
             var gitRepositories = new Dictionary<string, RemoteRepository>();
             foreach (var remote in repo.Network.Remotes)
             {
                 var remoteName = remote.Name;
-                gitRepositories[remoteName] = GitRepositoryFactory.Create(repo, remoteName);
+                gitRepositories[remoteName] = GitRepositoryFactory.Create(gitService, repo, remoteName);
             }
 
             return gitRepositories;

--- a/GitPullRequest.Services/GitRepository.cs
+++ b/GitPullRequest.Services/GitRepository.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using LibGit2Sharp;
+using LibGit2Sharp.Handlers;
+using Microsoft.Alm.Authentication;
+
+namespace GitPullRequest.Services
+{
+    public abstract class GitRepository
+    {
+        public string RemoteName { get; }
+        public string Url { get; }
+        public IDictionary<string, string> References { get; }
+
+        protected GitRepository(IRepository repo, string remoteName)
+        {
+            RemoteName = remoteName;
+            Url = GetRepositoryUrl(repo, remoteName);
+            References = GetReferences(repo, remoteName);
+        }
+
+        public abstract string GetPullRequestUrl(int number);
+
+        public abstract string GetCompareUrl(string friendlyBranchName);
+
+        public abstract int FindPullRequestForCanonicalName(string key);
+
+
+        public virtual string GetRepositoryUrl(IRepository repo, string remoteName)
+        {
+            return repo.Network.Remotes[remoteName].Url;
+        }
+
+        protected virtual IDictionary<string, string> GetReferences(IRepository repo, string remoteName)
+        {
+            var secrets = new SecretStore("git");
+            var auth = new BasicAuthentication(secrets);
+            var remoteUri = new Uri(GetRepositoryUrl(repo, remoteName));
+            var creds = auth.GetCredentials(new TargetUri(remoteUri.GetLeftPart(UriPartial.Authority)));
+
+            CredentialsHandler credentialsHandler =
+                (url, user, cred) => new UsernamePasswordCredentials
+                {
+                    Username = creds.Username,
+                    Password = creds.Password
+                };
+
+            var dictionary = new Dictionary<string, string>();
+            var remote = repo.Network.Remotes[remoteName];
+            var refs = repo.Network.ListReferences(remote, credentialsHandler);
+            foreach (var reference in refs)
+            {
+                var sha = GetTipForReference(repo, reference, credentialsHandler);
+                dictionary[reference.CanonicalName] = sha;
+            }
+
+            return dictionary;
+        }
+
+        protected virtual string GetTipForReference(IRepository repo, Reference reference, CredentialsHandler credentialsHandler)
+        {
+            return reference.TargetIdentifier;
+        }
+    }
+}

--- a/GitPullRequest.Services/GitRepositoryFactory.cs
+++ b/GitPullRequest.Services/GitRepositoryFactory.cs
@@ -1,13 +1,11 @@
-﻿using LibGit2Sharp;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using LibGit2Sharp;
 
 namespace GitPullRequest.Services
 {
     public static class GitRepositoryFactory
     {
-        public static GitRepository Create(IRepository repo, string remoteName)
+        public static RemoteRepository Create(IRepository repo, string remoteName)
         {
             var uri = new Uri(repo.Network.Remotes[remoteName].Url);
 
@@ -15,7 +13,7 @@ namespace GitPullRequest.Services
             {
                 return new GitHubRepository(repo, remoteName);
             }
-            else if (uri.Host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase))
+            else if (uri.Host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase) || uri.Host.Equals("dev.azure.com", StringComparison.OrdinalIgnoreCase))
             {
                 return new AzureDevOpsRepository(repo, remoteName);
             }

--- a/GitPullRequest.Services/GitRepositoryFactory.cs
+++ b/GitPullRequest.Services/GitRepositoryFactory.cs
@@ -7,7 +7,22 @@ namespace GitPullRequest.Services
     {
         public static RemoteRepository Create(GitService gitService, IRepository repo, string remoteName)
         {
-            var uri = new Uri(repo.Network.Remotes[remoteName].Url);
+            var url = repo.Network.Remotes[remoteName].Url;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+            {
+                return null;
+            }
+
+            if (!uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) &&
+                !uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (uri.GetLeftPart(UriPartial.Authority).Contains("@"))
+            {
+                return null;
+            }
 
             if (uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
             {

--- a/GitPullRequest.Services/GitRepositoryFactory.cs
+++ b/GitPullRequest.Services/GitRepositoryFactory.cs
@@ -5,17 +5,17 @@ namespace GitPullRequest.Services
 {
     public static class GitRepositoryFactory
     {
-        public static RemoteRepository Create(IRepository repo, string remoteName)
+        public static RemoteRepository Create(GitService gitService, IRepository repo, string remoteName)
         {
             var uri = new Uri(repo.Network.Remotes[remoteName].Url);
 
             if (uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
             {
-                return new GitHubRepository(repo, remoteName);
+                return new GitHubRepository(gitService, repo, remoteName);
             }
             else if (uri.Host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase) || uri.Host.Equals("dev.azure.com", StringComparison.OrdinalIgnoreCase))
             {
-                return new AzureDevOpsRepository(repo, remoteName);
+                return new AzureDevOpsRepository(gitService, repo, remoteName);
             }
             throw new NotSupportedException("Sorry, your git host is not supported!");
         }

--- a/GitPullRequest.Services/GitRepositoryFactory.cs
+++ b/GitPullRequest.Services/GitRepositoryFactory.cs
@@ -1,0 +1,25 @@
+﻿using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GitPullRequest.Services
+{
+    public static class GitRepositoryFactory
+    {
+        public static GitRepository Create(IRepository repo, string remoteName)
+        {
+            var uri = new Uri(repo.Network.Remotes[remoteName].Url);
+
+            if (uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return new GitHubRepository(repo, remoteName);
+            }
+            else if (uri.Host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return new AzureDevOpsRepository(repo, remoteName);
+            }
+            throw new NotSupportedException("Sorry, your git host is not supported!");
+        }
+    }
+}

--- a/GitPullRequest.Services/GitService.cs
+++ b/GitPullRequest.Services/GitService.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using LibGit2Sharp;
+using LibGit2Sharp.Handlers;
+using Microsoft.Alm.Authentication;
+
+namespace GitPullRequest.Services
+{
+    public class GitService
+    {
+        public IDictionary<string, string> ListReferences(IRepository repo, string remoteName)
+        {
+            var credentialsHandler = CreateCredentialsHandler(repo, remoteName);
+
+            var dictionary = new Dictionary<string, string>();
+            var remote = repo.Network.Remotes[remoteName];
+            var refs = repo.Network.ListReferences(remote, credentialsHandler);
+            foreach (var reference in refs)
+            {
+                dictionary[reference.CanonicalName] = reference.TargetIdentifier;
+            }
+
+            return dictionary;
+        }
+
+        public void Fetch(IRepository repo, string remoteName, string refSpec)
+        {
+            var credentialsHandler = CreateCredentialsHandler(repo, remoteName);
+            repo.Network.Fetch(remoteName, new[] { refSpec }, new FetchOptions { CredentialsProvider = credentialsHandler });
+        }
+
+        static CredentialsHandler CreateCredentialsHandler(IRepository repo, string remoteName)
+        {
+            var remote = repo.Network.Remotes[remoteName];
+            var remoteUri = new Uri(remote.Url);
+
+            var secrets = new SecretStore("git");
+            var auth = new BasicAuthentication(secrets);
+            var creds = auth.GetCredentials(new TargetUri(remoteUri.GetLeftPart(UriPartial.Authority)));
+
+            CredentialsHandler credentialsHandler =
+                (url, user, cred) => new UsernamePasswordCredentials
+                {
+                    Username = creds.Username,
+                    Password = creds.Password
+                };
+            return credentialsHandler;
+        }
+    }
+}

--- a/GitPullRequest.Services/GitService.cs
+++ b/GitPullRequest.Services/GitService.cs
@@ -36,7 +36,13 @@ namespace GitPullRequest.Services
 
             var secrets = new SecretStore("git");
             var auth = new BasicAuthentication(secrets);
-            var creds = auth.GetCredentials(new TargetUri(remoteUri.GetLeftPart(UriPartial.Authority)));
+
+            var targetUrl = remoteUri.GetLeftPart(UriPartial.Authority);
+            var creds = auth.GetCredentials(new TargetUri(targetUrl));
+            if (creds == null)
+            {
+                return null;
+            }
 
             CredentialsHandler credentialsHandler =
                 (url, user, cred) => new UsernamePasswordCredentials

--- a/GitPullRequest.Services/RemoteRepository.cs
+++ b/GitPullRequest.Services/RemoteRepository.cs
@@ -5,16 +5,14 @@ namespace GitPullRequest.Services
 {
     public abstract class RemoteRepository
     {
-        readonly GitService gitService;
-
+        protected GitService GitService { get; }
         public string RemoteName { get; }
         public string Url { get; }
         public IDictionary<string, string> References { get; }
 
         protected RemoteRepository(GitService gitService, IRepository repo, string remoteName)
         {
-            this.gitService = gitService;
-
+            GitService = gitService;
             RemoteName = remoteName;
             Url = GetRepositoryUrl(repo, remoteName);
             References = GetReferences(repo, remoteName);
@@ -33,7 +31,7 @@ namespace GitPullRequest.Services
 
         protected virtual IDictionary<string, string> GetReferences(IRepository repo, string remoteName)
         {
-            var refs = gitService.ListReferences(repo, remoteName);
+            var refs = GitService.ListReferences(repo, remoteName);
 
             var dictionary = new Dictionary<string, string>();
             foreach (var reference in refs)

--- a/GitPullRequest.Services/RemoteRepository.cs
+++ b/GitPullRequest.Services/RemoteRepository.cs
@@ -32,7 +32,7 @@ namespace GitPullRequest.Services
 
         protected virtual IDictionary<string, string> GetReferences(IRepository repo, string remoteName)
         {
-            CredentialsHandler credentialsHandler = CreateCredentialsHandler();
+            var credentialsHandler = CreateCredentialsHandler();
 
             var dictionary = new Dictionary<string, string>();
             var remote = repo.Network.Remotes[remoteName];

--- a/GitPullRequest.Services/RemoteRepository.cs
+++ b/GitPullRequest.Services/RemoteRepository.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 using Microsoft.Alm.Authentication;
 
 namespace GitPullRequest.Services
 {
-    public abstract class GitRepository
+    public abstract class RemoteRepository
     {
         public string RemoteName { get; }
         public string Url { get; }
         public IDictionary<string, string> References { get; }
 
-        protected GitRepository(IRepository repo, string remoteName)
+        protected RemoteRepository(IRepository repo, string remoteName)
         {
             RemoteName = remoteName;
             Url = GetRepositoryUrl(repo, remoteName);
@@ -26,17 +25,32 @@ namespace GitPullRequest.Services
 
         public abstract int FindPullRequestForCanonicalName(string key);
 
-
-        public virtual string GetRepositoryUrl(IRepository repo, string remoteName)
+        protected virtual string GetRepositoryUrl(IRepository repo, string remoteName)
         {
             return repo.Network.Remotes[remoteName].Url;
         }
 
         protected virtual IDictionary<string, string> GetReferences(IRepository repo, string remoteName)
         {
+            CredentialsHandler credentialsHandler = CreateCredentialsHandler();
+
+            var dictionary = new Dictionary<string, string>();
+            var remote = repo.Network.Remotes[remoteName];
+            var refs = repo.Network.ListReferences(remote, credentialsHandler);
+            foreach (var reference in refs)
+            {
+                var sha = GetTipForReference(repo, reference);
+                dictionary[reference.CanonicalName] = sha;
+            }
+
+            return dictionary;
+        }
+
+        protected CredentialsHandler CreateCredentialsHandler()
+        {
+            var remoteUri = new Uri(Url);
             var secrets = new SecretStore("git");
             var auth = new BasicAuthentication(secrets);
-            var remoteUri = new Uri(GetRepositoryUrl(repo, remoteName));
             var creds = auth.GetCredentials(new TargetUri(remoteUri.GetLeftPart(UriPartial.Authority)));
 
             CredentialsHandler credentialsHandler =
@@ -45,20 +59,10 @@ namespace GitPullRequest.Services
                     Username = creds.Username,
                     Password = creds.Password
                 };
-
-            var dictionary = new Dictionary<string, string>();
-            var remote = repo.Network.Remotes[remoteName];
-            var refs = repo.Network.ListReferences(remote, credentialsHandler);
-            foreach (var reference in refs)
-            {
-                var sha = GetTipForReference(repo, reference, credentialsHandler);
-                dictionary[reference.CanonicalName] = sha;
-            }
-
-            return dictionary;
+            return credentialsHandler;
         }
 
-        protected virtual string GetTipForReference(IRepository repo, Reference reference, CredentialsHandler credentialsHandler)
+        protected virtual string GetTipForReference(IRepository repo, Reference reference)
         {
             return reference.TargetIdentifier;
         }

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -39,7 +39,8 @@ namespace GitPullRequest
                 return;
             }
 
-            var service = new GitPullRequestService();
+            var gitService = new GitService();
+            var service = new GitPullRequestService(gitService);
             using (var repo = new Repository(repoPath))
             {
                 if (Prune)

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -51,18 +51,19 @@ namespace GitPullRequest
 
         void BrowsePullRequest(GitPullRequestService service, Repository repo)
         {
-            var gitHubRepositories = service.GetGitHubRepositories(repo);
+            var gitRepositories = service.GetGitRepositories(repo);
 
-            var prs = (PullRequestNumber == 0 ? service.FindPullRequests(gitHubRepositories, repo.Head) :
+            var prs = (PullRequestNumber == 0 ? service.FindPullRequests(gitRepositories, repo.Head) :
                 repo.Branches
-                    .SelectMany(b => service.FindPullRequests(gitHubRepositories, b))
-                    .Where(pr => pr.Number == PullRequestNumber)).ToList();
+                    .SelectMany(b => service.FindPullRequests(gitRepositories, b))
+                    .Where(pr => pr.Number == PullRequestNumber)
+                    .Distinct()).ToList();
 
             if (prs.Count > 0)
             {
                 foreach (var pr in prs)
                 {
-                    Browse(service.GetPullRequestUrl(pr.Repository, pr.Number));
+                    Browse(pr.Repository.GetPullRequestUrl(pr.Number));
                 }
 
                 return;
@@ -74,7 +75,7 @@ namespace GitPullRequest
                 return;
             }
 
-            var compareUrl = service.FindCompareUrl(gitHubRepositories, repo);
+            var compareUrl = service.FindCompareUrl(gitRepositories, repo);
             if (compareUrl != null)
             {
                 Browse(compareUrl);
@@ -86,10 +87,10 @@ namespace GitPullRequest
 
         void ListBranches(GitPullRequestService service, Repository repo)
         {
-            var gitHubRepositories = service.GetGitHubRepositories(repo);
+            var gitRepositories = service.GetGitRepositories(repo);
             var prs = repo.Branches
                 .Where(b => All || !b.IsRemote)
-                .SelectMany(b => service.FindPullRequests(gitHubRepositories, b), (b, p) => (Branch: b, PullRequest: p))
+                .SelectMany(b => service.FindPullRequests(gitRepositories, b), (b, p) => (Branch: b, PullRequest: p))
                 .Where(bp => PullRequestNumber == 0 || bp.PullRequest.Number == PullRequestNumber)
                 .OrderBy(bp => bp.Branch.IsRemote)
                 .ThenBy(bp => bp.PullRequest.Number)

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -135,7 +135,7 @@ namespace GitPullRequest
 
         void PruneBranches(GitPullRequestService service, Repository repo)
         {
-            var gitHubRepositories = service.GetGitHubRepositories(repo);
+            var gitHubRepositories = service.GetGitRepositories(repo);
             var prs = repo.Branches
                 .Where(b => !b.IsRemote)
                 .SelectMany(b => service.FindPullRequests(gitHubRepositories, b), (b, p) => (Branch: b, PullRequest: p))


### PR DESCRIPTION
Since this is called GitPullRequest and not Git*Hub*PullRequest I thought I'd help it live up to its name by supporting another git service provider. Plus this means I can use it in all of my repos and not just some :)

This is a fairly heavy PR though with some caveats:
* The "design" of multiple repositories is as light weight as I could make it. There are a bunch of improvements that could be made, moving code to more places.
* There is no proper hook up for repositories, just a lazy factory method.
* Azure DevOps support is a little slow, as it has to fetch in order to find the right commit (see code in comments)
* I had to delete a test, and couldn't easily rewrite (though some of the above mentioned clean up would help with that)

Please let me know if you want me to make any changes here, particularly if you already had a design in mind for this sort of thing.