### PR TITLE
Add --shell option to use built in git authentication

### DIFF
--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -24,7 +24,7 @@ public class GitPullRequestServiceTests
             {
                 AddRemoteReferences(repo, remote, new Dictionary<string, string> { { referenceCanonicalName, "refSha" } });
             }
-            GitPullRequestService target = CreateGitPullRequestService();
+            var target = CreateGitPullRequestService();
             var gitHubRepositories = target.GetGitRepositories(repo);
 
             var compareUrl = target.FindCompareUrl(gitHubRepositories, repo);
@@ -99,7 +99,7 @@ public class GitPullRequestServiceTests
 
     static GitPullRequestService CreateGitPullRequestService()
     {
-        var gitService = new GitService();
+        var gitService = new LibGitService();
         return new GitPullRequestService(gitService);
     }
 

--- a/GitPullRequest.Services/AzureDevOpsRepository.cs
+++ b/GitPullRequest.Services/AzureDevOpsRepository.cs
@@ -8,7 +8,7 @@ namespace GitPullRequest.Services
 {
     internal class AzureDevOpsRepository : RemoteRepository
     {
-        public AzureDevOpsRepository(GitService gitService, IRepository repo, string remoteName)
+        public AzureDevOpsRepository(IGitService gitService, IRepository repo, string remoteName)
             : base(gitService, repo, remoteName)
         {
         }

--- a/GitPullRequest.Services/GitHubRepository.cs
+++ b/GitPullRequest.Services/GitHubRepository.cs
@@ -5,7 +5,7 @@ namespace GitPullRequest.Services
 {
     internal class GitHubRepository : RemoteRepository
     {
-        public GitHubRepository(GitService gitService, IRepository repo, string remoteName)
+        public GitHubRepository(IGitService gitService, IRepository repo, string remoteName)
             : base(gitService, repo, remoteName)
         {
         }

--- a/GitPullRequest.Services/GitPullRequest.Services.csproj
+++ b/GitPullRequest.Services/GitPullRequest.Services.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -6,9 +6,9 @@ namespace GitPullRequest.Services
 {
     public class GitPullRequestService
     {
-        readonly GitService gitService;
+        readonly IGitService gitService;
 
-        public GitPullRequestService(GitService gitService)
+        public GitPullRequestService(IGitService gitService)
         {
             this.gitService = gitService;
         }

--- a/GitPullRequest.Services/GitRepositoryFactory.cs
+++ b/GitPullRequest.Services/GitRepositoryFactory.cs
@@ -5,7 +5,7 @@ namespace GitPullRequest.Services
 {
     public static class GitRepositoryFactory
     {
-        public static RemoteRepository Create(GitService gitService, IRepository repo, string remoteName)
+        public static RemoteRepository Create(IGitService gitService, IRepository repo, string remoteName)
         {
             var url = repo.Network.Remotes[remoteName].Url;
             if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))

--- a/GitPullRequest.Services/IGitService.cs
+++ b/GitPullRequest.Services/IGitService.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using LibGit2Sharp;
+
+namespace GitPullRequest.Services
+{
+    public interface IGitService
+    {
+        void Fetch(IRepository repo, string remoteName, string refSpec);
+        IDictionary<string, string> ListReferences(IRepository repo, string remoteName);
+    }
+}

--- a/GitPullRequest.Services/LibGitService.cs
+++ b/GitPullRequest.Services/LibGitService.cs
@@ -6,7 +6,7 @@ using Microsoft.Alm.Authentication;
 
 namespace GitPullRequest.Services
 {
-    public class GitService
+    public class LibGitService : IGitService
     {
         public IDictionary<string, string> ListReferences(IRepository repo, string remoteName)
         {
@@ -14,7 +14,8 @@ namespace GitPullRequest.Services
 
             var dictionary = new Dictionary<string, string>();
             var remote = repo.Network.Remotes[remoteName];
-            var refs = repo.Network.ListReferences(remote, credentialsHandler);
+            var refs = credentialsHandler != null ?
+                repo.Network.ListReferences(remote, credentialsHandler) : repo.Network.ListReferences(remote);
             foreach (var reference in refs)
             {
                 dictionary[reference.CanonicalName] = reference.TargetIdentifier;

--- a/GitPullRequest.Services/RemoteRepository.cs
+++ b/GitPullRequest.Services/RemoteRepository.cs
@@ -5,12 +5,12 @@ namespace GitPullRequest.Services
 {
     public abstract class RemoteRepository
     {
-        protected GitService GitService { get; }
+        protected IGitService GitService { get; }
         public string RemoteName { get; }
         public string Url { get; }
         public IDictionary<string, string> References { get; }
 
-        protected RemoteRepository(GitService gitService, IRepository repo, string remoteName)
+        protected RemoteRepository(IGitService gitService, IRepository repo, string remoteName)
         {
             GitService = gitService;
             RemoteName = remoteName;

--- a/GitPullRequest.Services/ShellGitService.cs
+++ b/GitPullRequest.Services/ShellGitService.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using LibGit2Sharp;
+
+namespace GitPullRequest.Services
+{
+    public class ShellGitService : IGitService
+    {
+        public IDictionary<string, string> ListReferences(IRepository repo, string remoteName)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"ls-remote {remoteName}",
+                WorkingDirectory = repo.Info.WorkingDirectory,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            var dictionary = new Dictionary<string, string>();
+            using (var process = Process.Start(startInfo))
+            {
+                while (true)
+                {
+                    var line = process.StandardOutput.ReadLine();
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    var split = line.Split('\t');
+                    var targetIdentifier = split[0];
+                    var canonicalName = split[1];
+                    dictionary[canonicalName] = targetIdentifier;
+                }
+            }
+
+            return dictionary;
+        }
+
+        public void Fetch(IRepository repo, string remoteName, string refSpec)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"fetch {remoteName} {refSpec}",
+                WorkingDirectory = repo.Info.WorkingDirectory,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            var dictionary = new Dictionary<string, string>();
+            using (var process = Process.Start(startInfo))
+            {
+                while (true)
+                {
+                    var line = process.StandardOutput.ReadLine();
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    Console.WriteLine(line);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
_Depends on #16_

Add option to shell out to git for `git ls-remote` (and `git fetch` for Azure DevOps). This allows the user to use built in git authentication if the LibGit2Sharp CredentialsHandler isn't available (e.g. for private repositories on Linux).

This is a partial fix for #11