### PR TITLE
Add --remote option for listing PRs on specific remote

### DIFF
--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -36,7 +36,7 @@ namespace GitPullRequest.Services
         {
             var isDeleted = false;
             string sha = null;
-            if (branch.IsTracking)
+            if (branch.IsTracking || branch.IsRemote)
             {
                 var gitRepository = gitRepositories[branch.RemoteName];
                 var references = gitRepository.References;


### PR DESCRIPTION
List remote branches with associated pull requests. Ignore remote branches that exist on the target repository (these were most likely forked with the repository).