### PR TITLE
Output progress when using LibGit2Sharp to fetch

### DIFF
--- a/GitPullRequest.Services/LibGitService.cs
+++ b/GitPullRequest.Services/LibGitService.cs
@@ -27,7 +27,17 @@ namespace GitPullRequest.Services
         public void Fetch(IRepository repo, string remoteName, string refSpec)
         {
             var credentialsHandler = CreateCredentialsHandler(repo, remoteName);
-            repo.Network.Fetch(remoteName, new[] { refSpec }, new FetchOptions { CredentialsProvider = credentialsHandler });
+            ProgressHandler progressHandler = text =>
+            {
+                Console.Write(text);
+                return true;
+            };
+
+            repo.Network.Fetch(remoteName, new[] { refSpec }, new FetchOptions
+            {
+                CredentialsProvider = credentialsHandler,
+                OnProgress = progressHandler
+            });
         }
 
         static CredentialsHandler CreateCredentialsHandler(IRepository repo, string remoteName)


### PR DESCRIPTION
Make fetching using LibGit2Sharp report the progress of a fetch in a similar way to how git fetch does.

Since fetch can take a while, this will hopefully reassure the user that it hasn't hung!

@davidwengier FYI ☝️ 