### PR TITLE
Mark non-tracking branches with (?)

### DIFF
--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -147,7 +147,7 @@ namespace GitPullRequest
                 var isHead = bp.Branch.IsCurrentRepositoryHead ? "* " : "  ";
                 var remotePrefix = bp.PullRequest.Repository.RemoteName != "origin" ? bp.PullRequest.Repository.RemoteName : "";
 
-                var branchRemoteName = bp.Branch.RemoteName ?? "";
+                var branchRemoteName = bp.Branch.RemoteName ?? "?";
                 var postfix = (bp.PullRequest.IsDeleted ? "x " : "") + (branchRemoteName != "origin" ? branchRemoteName : "");
                 if (postfix.Length > 0)
                 {


### PR DESCRIPTION
For example `foo` has no tracking branch but `fixes/33-multiple-remotes-same-url` has a deleted tracking branch.

```
  #1 foo (?)
  #35 fixes/33-multiple-remotes-same-url (x)
```

Fixes #36