### PR TITLE
Don't greedily list references from all remotes

### DIFF
--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -25,7 +25,7 @@ public class GitPullRequestServiceTests
                 AddRemoteReferences(repo, remote, new Dictionary<string, string> { { referenceCanonicalName, "refSha" } });
             }
             var target = CreateGitPullRequestService();
-            var gitHubRepositories = target.GetGitRepositories(repo);
+            var gitHubRepositories = target.GetRemoteRepositoryCache(repo);
 
             var compareUrl = target.FindCompareUrl(gitHubRepositories, repo);
 
@@ -40,7 +40,7 @@ public class GitPullRequestServiceTests
         {
             var repo = CreateRepository("sha", null, null, Array.Empty<Remote>());
             var target = CreateGitPullRequestService();
-            var gitHubRepositories = target.GetGitRepositories(repo);
+            var gitHubRepositories = target.GetRemoteRepositoryCache(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 
@@ -62,7 +62,7 @@ public class GitPullRequestServiceTests
                     { $"refs/pull/{number}/head", prSha }
                 });
             var target = CreateGitPullRequestService();
-            var gitHubRepositories = target.GetGitRepositories(repo);
+            var gitHubRepositories = target.GetRemoteRepositoryCache(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 
@@ -86,7 +86,7 @@ public class GitPullRequestServiceTests
             AddRemoteReferences(repo, originRemote, new Dictionary<string, string> { { "refs/heads/one", prSha } });
             AddRemoteReferences(repo, upstreamRemote, new Dictionary<string, string> { { $"refs/pull/{number}/head", prSha } });
             var target = CreateGitPullRequestService();
-            var gitHubRepositories = target.GetGitRepositories(repo);
+            var gitHubRepositories = target.GetRemoteRepositoryCache(repo);
 
             var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
 

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -40,9 +40,10 @@ public class GitPullRequestServiceTests
         {
             var repo = CreateRepository("sha", null, null, Array.Empty<Remote>());
             var target = CreateGitPullRequestService();
-            var gitHubRepositories = target.GetRemoteRepositoryCache(repo);
+            var remoteRepositoryCache = target.GetRemoteRepositoryCache(repo);
+            var upstreamRepositories = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
 
-            var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
+            var prs = target.FindPullRequests(remoteRepositoryCache, upstreamRepositories, repo.Head);
 
             Assert.That(prs, Is.Empty);
         }
@@ -62,9 +63,10 @@ public class GitPullRequestServiceTests
                     { $"refs/pull/{number}/head", prSha }
                 });
             var target = CreateGitPullRequestService();
-            var gitHubRepositories = target.GetRemoteRepositoryCache(repo);
+            var remoteRepositoryCache = target.GetRemoteRepositoryCache(repo);
+            var upstreamRepositories = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
 
-            var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
+            var prs = target.FindPullRequests(remoteRepositoryCache, upstreamRepositories, repo.Head);
 
             var pr = prs.FirstOrDefault();
             Assert.That(pr.Repository.RemoteName, Is.EqualTo(remoteName));
@@ -87,8 +89,11 @@ public class GitPullRequestServiceTests
             AddRemoteReferences(repo, upstreamRemote, new Dictionary<string, string> { { $"refs/pull/{number}/head", prSha } });
             var target = CreateGitPullRequestService();
             var gitHubRepositories = target.GetRemoteRepositoryCache(repo);
+            var upstreamRepositories = repo.Network.Remotes
+                .Select(r => gitHubRepositories[r.Name])
+                .ToList();
 
-            var prs = target.FindPullRequests(gitHubRepositories, repo.Head);
+            var prs = target.FindPullRequests(gitHubRepositories, upstreamRepositories, repo.Head);
 
             var pr = prs.FirstOrDefault();
             Assert.That(pr.Repository.Url, Is.EqualTo(upstreamUrl));
@@ -121,6 +126,13 @@ public class GitPullRequestServiceTests
         remote.Name.Returns(name);
         remote.Url.Returns(url);
         return remote;
+    }
+
+    static IList<RemoteRepository> CreateUpstreamRepositoires(RemoteRepositoryCache remoteRepositoryCache, IRepository repo)
+    {
+        return repo.Network.Remotes
+            .Select(r => remoteRepositoryCache[r.Name])
+            .ToList();
     }
 
     static Branch CreateBranch(string sha, string remoteName, string upstreamBranchCanonicalName)

--- a/GitPullRequest.Services/RemoteRepositoryCache.cs
+++ b/GitPullRequest.Services/RemoteRepositoryCache.cs
@@ -1,0 +1,21 @@
+﻿using LibGit2Sharp;
+using System.Collections.Generic;
+
+namespace GitPullRequest.Services
+{
+    public class RemoteRepositoryCache : Dictionary<string, RemoteRepository>
+    {
+        public RemoteRepositoryCache(IGitService gitService, IRepository repo)
+        {
+            foreach (var remote in repo.Network.Remotes)
+            {
+                var remoteName = remote.Name;
+                var hostedRepository = GitRepositoryFactory.Create(gitService, repo, remote.Name);
+                if (hostedRepository != null)
+                {
+                    this[remoteName] = hostedRepository;
+                }
+            }
+        }
+    }
+}

--- a/GitPullRequest.Services/RemoteRepositoryCache.cs
+++ b/GitPullRequest.Services/RemoteRepositoryCache.cs
@@ -1,20 +1,37 @@
-﻿using LibGit2Sharp;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using LibGit2Sharp;
 
 namespace GitPullRequest.Services
 {
-    public class RemoteRepositoryCache : Dictionary<string, RemoteRepository>
+    public class RemoteRepositoryCache
     {
+        readonly IGitService gitService;
+        readonly IRepository repo;
+        readonly Dictionary<string, RemoteRepository> cache;
+
         public RemoteRepositoryCache(IGitService gitService, IRepository repo)
         {
-            foreach (var remote in repo.Network.Remotes)
+            this.gitService = gitService;
+            this.repo = repo;
+            cache = new Dictionary<string, RemoteRepository>();
+        }
+
+        public RemoteRepository this[string remoteName]
+        {
+            get
             {
-                var remoteName = remote.Name;
-                var hostedRepository = GitRepositoryFactory.Create(gitService, repo, remote.Name);
-                if (hostedRepository != null)
+                if (!cache.ContainsKey(remoteName))
                 {
-                    this[remoteName] = hostedRepository;
+                    var remoteRepository = GitRepositoryFactory.Create(gitService, repo, remoteName);
+                    if (remoteRepository != null)
+                    {
+                        cache[remoteName] = remoteRepository;
+                    }
+
+                    cache[remoteName] = remoteRepository;
                 }
+
+                return cache[remoteName];
             }
         }
     }

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -73,11 +73,11 @@ namespace GitPullRequest
 
         void BrowsePullRequest(GitPullRequestService service, Repository repo)
         {
-            var gitRepositories = service.GetGitRepositories(repo);
+            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo);
 
-            var prs = (PullRequestNumber == 0 ? service.FindPullRequests(gitRepositories, repo.Head) :
+            var prs = (PullRequestNumber == 0 ? service.FindPullRequests(remoteRepositoryCache, repo.Head) :
                 repo.Branches
-                    .SelectMany(b => service.FindPullRequests(gitRepositories, b))
+                    .SelectMany(b => service.FindPullRequests(remoteRepositoryCache, b))
                     .Where(pr => pr.Number == PullRequestNumber)
                     .Distinct()).ToList();
 
@@ -99,7 +99,7 @@ namespace GitPullRequest
                 return;
             }
 
-            var compareUrl = service.FindCompareUrl(gitRepositories, repo);
+            var compareUrl = service.FindCompareUrl(remoteRepositoryCache, repo);
             if (compareUrl != null)
             {
                 Console.WriteLine(compareUrl);
@@ -112,7 +112,7 @@ namespace GitPullRequest
 
         void ListBranches(GitPullRequestService service, Repository repo, string remoteName)
         {
-            var gitRepositories = service.GetGitRepositories(repo);
+            var gitRepositories = service.GetRemoteRepositoryCache(repo);
             var prs = repo.Branches
                 .Where(b => remoteName == null && !b.IsRemote || remoteName != null && b.IsRemote && b.RemoteName == remoteName)
                 .SelectMany(b => service.FindPullRequests(gitRepositories, b), (b, p) => (Branch: b, PullRequest: p))
@@ -160,7 +160,7 @@ namespace GitPullRequest
 
         void PruneBranches(GitPullRequestService service, Repository repo)
         {
-            var gitHubRepositories = service.GetGitRepositories(repo);
+            var gitHubRepositories = service.GetRemoteRepositoryCache(repo);
             var prs = repo.Branches
                 .Where(b => !b.IsRemote)
                 .SelectMany(b => service.FindPullRequests(gitHubRepositories, b), (b, p) => (Branch: b, PullRequest: p))

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Diagnostics;
 using System.ComponentModel;
+using System.Collections.Generic;
 using LibGit2Sharp;
 using GitPullRequest.Services;
 using McMaster.Extensions.CommandLineUtils;
@@ -74,10 +75,11 @@ namespace GitPullRequest
         void BrowsePullRequest(GitPullRequestService service, Repository repo)
         {
             var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo);
+            var upstreamRepositoires = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
 
-            var prs = (PullRequestNumber == 0 ? service.FindPullRequests(remoteRepositoryCache, repo.Head) :
+            var prs = (PullRequestNumber == 0 ? service.FindPullRequests(remoteRepositoryCache, upstreamRepositoires, repo.Head) :
                 repo.Branches
-                    .SelectMany(b => service.FindPullRequests(remoteRepositoryCache, b))
+                    .SelectMany(b => service.FindPullRequests(remoteRepositoryCache, upstreamRepositoires, b))
                     .Where(pr => pr.Number == PullRequestNumber)
                     .Distinct()).ToList();
 
@@ -112,10 +114,12 @@ namespace GitPullRequest
 
         void ListBranches(GitPullRequestService service, Repository repo, string remoteName)
         {
-            var gitRepositories = service.GetRemoteRepositoryCache(repo);
+            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo);
+            var upstreamRepositoires = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
+
             var prs = repo.Branches
                 .Where(b => remoteName == null && !b.IsRemote || remoteName != null && b.IsRemote && b.RemoteName == remoteName)
-                .SelectMany(b => service.FindPullRequests(gitRepositories, b), (b, p) => (Branch: b, PullRequest: p))
+                .SelectMany(b => service.FindPullRequests(remoteRepositoryCache, upstreamRepositoires, b), (b, p) => (Branch: b, PullRequest: p))
                 .Where(bp => PullRequestNumber == 0 || bp.PullRequest.Number == PullRequestNumber)
                 .OrderBy(bp => bp.Branch.IsRemote)
                 .ThenBy(bp => bp.PullRequest.Number)
@@ -160,10 +164,12 @@ namespace GitPullRequest
 
         void PruneBranches(GitPullRequestService service, Repository repo)
         {
-            var gitHubRepositories = service.GetRemoteRepositoryCache(repo);
+            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo);
+            var upstreamRepositoires = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
+
             var prs = repo.Branches
                 .Where(b => !b.IsRemote)
-                .SelectMany(b => service.FindPullRequests(gitHubRepositories, b), (b, p) => (Branch: b, PullRequest: p))
+                .SelectMany(b => service.FindPullRequests(remoteRepositoryCache, upstreamRepositoires, b), (b, p) => (Branch: b, PullRequest: p))
                 .Where(bp => bp.PullRequest.IsDeleted)
                 .Where(bp => PullRequestNumber == 0 || bp.PullRequest.Number == PullRequestNumber)
                 .GroupBy(bp => bp.Branch)
@@ -188,6 +194,18 @@ namespace GitPullRequest
                     repo.Branches.Remove(bp.Branch);
                 }
             }
+        }
+
+        static IList<RemoteRepository> CreateUpstreamRepositoires(RemoteRepositoryCache remoteRepositoryCache, IRepository repo)
+        {
+            // Only consider one repository per URL and prioritize ones with a remote named "origin"
+            return repo.Network.Remotes
+                .Select(r => remoteRepositoryCache[r.Name])
+                .GroupBy(r => r.Url)
+                .Select(g => g
+                    .OrderBy(r => r.RemoteName == "origin" ? 0 : 1)
+                    .First())
+                .ToList();
         }
 
         bool TryBrowse(string url)


### PR DESCRIPTION
A user might have many remotes defined that aren't tracked by any local branches. Rather than greedily reading references from all remotes, read (and cache) the references on demand. This will allow us to only read remote references for upstream and any active tracking branches.