### PR TITLE
Add support for alternative remote URL types

### DIFF
--- a/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
+++ b/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
@@ -1,0 +1,43 @@
+﻿using GitPullRequest.Services;
+using LibGit2Sharp;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+public class GitHubRepositoryTests
+{
+    public class TheUrlProperty
+    {
+        [TestCase("https://github.com/jcansdale/git-pr", "https://github.com/jcansdale/git-pr")]
+        [TestCase("git@github.com:jcansdale/GitDiffMargin.git", "https://github.com/jcansdale/GitDiffMargin")]
+        public void Url(string remoteUrl, string expectUrl)
+        {
+            var gitService = Substitute.For<IGitService>();
+            var remoteName = "remoteName";
+            var repo = CreateRepository(remoteName, remoteUrl);
+
+            var target = new GitHubRepository(gitService, repo, remoteName);
+
+            Assert.That(target.Url, Is.EqualTo(expectUrl));
+        }
+
+        private static IRepository CreateRepository(string remoteName, string remoteUrl)
+        {
+            var repository = Substitute.For<IRepository>();
+            var network = Substitute.For<Network>();
+            var remoteCollection = Substitute.For<RemoteCollection>();
+            var remote = Substitute.For<Remote>();
+            remote.Name.Returns(remoteName);
+            remote.Url.Returns(remoteUrl);
+            remoteCollection[remoteName].Returns(remote);
+            network.Remotes.Returns(remoteCollection);
+            repository.Network.Returns(network);
+            return repository;
+        }
+    }
+
+}

--- a/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
+++ b/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
@@ -7,10 +7,13 @@ public class GitHubRepositoryTests
 {
     public class TheUrlProperty
     {
-        [TestCase("https://github.com/jcansdale/git-pr", "https://github.com/jcansdale/git-pr")]
-        [TestCase("https://github.com/jcansdale/git-pr.git", "https://github.com/jcansdale/git-pr")]
-        [TestCase("https://github.com/jcansdale/git-pr.git/", "https://github.com/jcansdale/git-pr")]
-        [TestCase("git@github.com:jcansdale/GitDiffMargin.git", "https://github.com/jcansdale/GitDiffMargin")]
+        [TestCase("https://github.com/owner/repo", "https://github.com/owner/repo")]
+        [TestCase("https://github.com/owner/repo.git", "https://github.com/owner/repo")]
+        [TestCase("https://github.com/owner/repo.git/", "https://github.com/owner/repo")]
+        [TestCase("git://github.com/owner/repo", "https://github.com/owner/repo")]
+        [TestCase("git@github.com:owner/repo.git", "https://github.com/owner/repo")]
+        [TestCase("ssh://git@github.com/owner/repo.git", "https://github.com/owner/repo")]
+        [TestCase("http://github.com/owner/repo", "http://github.com/owner/repo")] // Keeps http
         [TestCase(@"c:\source\repo", "file:///c:/source/repo")]
         public void Url(string remoteUrl, string expectUrl)
         {

--- a/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
+++ b/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
@@ -8,6 +8,8 @@ public class GitHubRepositoryTests
     public class TheUrlProperty
     {
         [TestCase("https://github.com/jcansdale/git-pr", "https://github.com/jcansdale/git-pr")]
+        [TestCase("https://github.com/jcansdale/git-pr.git", "https://github.com/jcansdale/git-pr")]
+        [TestCase("https://github.com/jcansdale/git-pr.git/", "https://github.com/jcansdale/git-pr")]
         [TestCase("git@github.com:jcansdale/GitDiffMargin.git", "https://github.com/jcansdale/GitDiffMargin")]
         [TestCase(@"c:\source\repo", "file:///c:/source/repo")]
         public void Url(string remoteUrl, string expectUrl)

--- a/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
+++ b/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
@@ -2,11 +2,6 @@
 using LibGit2Sharp;
 using NSubstitute;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 public class GitHubRepositoryTests
 {

--- a/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
+++ b/GitPullRequest.Services.Tests/GitHubRepositoryTests.cs
@@ -9,6 +9,7 @@ public class GitHubRepositoryTests
     {
         [TestCase("https://github.com/jcansdale/git-pr", "https://github.com/jcansdale/git-pr")]
         [TestCase("git@github.com:jcansdale/GitDiffMargin.git", "https://github.com/jcansdale/GitDiffMargin")]
+        [TestCase(@"c:\source\repo", "file:///c:/source/repo")]
         public void Url(string remoteUrl, string expectUrl)
         {
             var gitService = Substitute.For<IGitService>();

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -105,7 +105,7 @@ public class GitPullRequestServiceTests
     static GitPullRequestService CreateGitPullRequestService()
     {
         var gitService = new LibGitService();
-        var factory = new RemoteRepositoryFactory(gitService);
+        var factory = new RemoteRepositoryFactory(new LibGitService(), new ShellGitService(), false);
         return new GitPullRequestService(factory);
     }
 

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -105,7 +105,8 @@ public class GitPullRequestServiceTests
     static GitPullRequestService CreateGitPullRequestService()
     {
         var gitService = new LibGitService();
-        return new GitPullRequestService(gitService);
+        var factory = new RemoteRepositoryFactory(gitService);
+        return new GitPullRequestService(factory);
     }
 
     static IRepository CreateRepository(

--- a/GitPullRequest.Services/GitHubRepository.cs
+++ b/GitPullRequest.Services/GitHubRepository.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using GitHub.Primitives;
 using LibGit2Sharp;
 
 namespace GitPullRequest.Services
@@ -13,12 +14,8 @@ namespace GitPullRequest.Services
         protected override string GetRepositoryUrl(IRepository repo, string remoteName)
         {
             var url = base.GetRepositoryUrl(repo, remoteName);
-            var postfix = ".git";
-            if (url.EndsWith(postfix))
-            {
-                url = url.Substring(0, url.Length - postfix.Length);
-            }
-            return url;
+            var uriString = new UriString(url);
+            return uriString.ToRepositoryUrl()?.ToString() ?? "";
         }
 
         public override int FindPullRequestForCanonicalName(string canonicalName)

--- a/GitPullRequest.Services/GitHubRepository.cs
+++ b/GitPullRequest.Services/GitHubRepository.cs
@@ -3,7 +3,7 @@ using LibGit2Sharp;
 
 namespace GitPullRequest.Services
 {
-    internal class GitHubRepository : RemoteRepository
+    public class GitHubRepository : RemoteRepository
     {
         public GitHubRepository(IGitService gitService, IRepository repo, string remoteName)
             : base(gitService, repo, remoteName)

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -6,16 +6,16 @@ namespace GitPullRequest.Services
 {
     public class GitPullRequestService
     {
-        readonly IGitService gitService;
+        readonly RemoteRepositoryFactory remoteRepositoryFactory;
 
-        public GitPullRequestService(IGitService gitService)
+        public GitPullRequestService(RemoteRepositoryFactory remoteRepositoryFactory)
         {
-            this.gitService = gitService;
+            this.remoteRepositoryFactory = remoteRepositoryFactory;
         }
 
         public RemoteRepositoryCache GetRemoteRepositoryCache(IRepository repo)
         {
-            return new RemoteRepositoryCache(gitService, repo);
+            return new RemoteRepositoryCache(remoteRepositoryFactory, repo);
         }
 
         public IList<(RemoteRepository Repository, int Number, bool IsDeleted)> FindPullRequests(

--- a/GitPullRequest.Services/RemoteRepositoryCache.cs
+++ b/GitPullRequest.Services/RemoteRepositoryCache.cs
@@ -5,13 +5,13 @@ namespace GitPullRequest.Services
 {
     public class RemoteRepositoryCache
     {
-        readonly IGitService gitService;
+        readonly RemoteRepositoryFactory remoteRepositoryFactory;
         readonly IRepository repo;
         readonly Dictionary<string, RemoteRepository> cache;
 
-        public RemoteRepositoryCache(IGitService gitService, IRepository repo)
+        public RemoteRepositoryCache(RemoteRepositoryFactory remoteRepositoryFactory, IRepository repo)
         {
-            this.gitService = gitService;
+            this.remoteRepositoryFactory = remoteRepositoryFactory;
             this.repo = repo;
             cache = new Dictionary<string, RemoteRepository>();
         }
@@ -22,7 +22,7 @@ namespace GitPullRequest.Services
             {
                 if (!cache.ContainsKey(remoteName))
                 {
-                    var remoteRepository = GitRepositoryFactory.Create(gitService, repo, remoteName);
+                    var remoteRepository = remoteRepositoryFactory.Create(repo, remoteName);
                     if (remoteRepository != null)
                     {
                         cache[remoteName] = remoteRepository;

--- a/GitPullRequest.Services/RemoteRepositoryCache.cs
+++ b/GitPullRequest.Services/RemoteRepositoryCache.cs
@@ -1,37 +1,50 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using LibGit2Sharp;
 
 namespace GitPullRequest.Services
 {
     public class RemoteRepositoryCache
     {
+        readonly Dictionary<string, RemoteRepository> cache = new Dictionary<string, RemoteRepository>();
+
         readonly RemoteRepositoryFactory remoteRepositoryFactory;
         readonly IRepository repo;
-        readonly Dictionary<string, RemoteRepository> cache;
+        readonly Action<Exception> exceptionLogger;
 
-        public RemoteRepositoryCache(RemoteRepositoryFactory remoteRepositoryFactory, IRepository repo)
+        public RemoteRepositoryCache(
+            RemoteRepositoryFactory remoteRepositoryFactory,
+            IRepository repo,
+            Action<Exception> exceptionLogger)
         {
             this.remoteRepositoryFactory = remoteRepositoryFactory;
             this.repo = repo;
-            cache = new Dictionary<string, RemoteRepository>();
+            this.exceptionLogger = exceptionLogger;
         }
 
-        public RemoteRepository this[string remoteName]
+        public RemoteRepository FindRemoteRepository(string remoteName)
         {
-            get
+            if (!cache.ContainsKey(remoteName))
             {
-                if (!cache.ContainsKey(remoteName))
-                {
-                    var remoteRepository = remoteRepositoryFactory.Create(repo, remoteName);
-                    if (remoteRepository != null)
-                    {
-                        cache[remoteName] = remoteRepository;
-                    }
+                TryCreateRemoteRepository(remoteName, out RemoteRepository remoteRepository);
+                cache[remoteName] = remoteRepository;
+            }
 
-                    cache[remoteName] = remoteRepository;
-                }
+            return cache[remoteName];
+        }
 
-                return cache[remoteName];
+        bool TryCreateRemoteRepository(string remoteName, out RemoteRepository remoteRepository)
+        {
+            try
+            {
+                remoteRepository = remoteRepositoryFactory.Create(repo, remoteName);
+                return true;
+            }
+            catch (Exception e)
+            {
+                exceptionLogger(e);
+                remoteRepository = null;
+                return false;
             }
         }
     }

--- a/GitPullRequest.Services/RemoteRepositoryFactory.cs
+++ b/GitPullRequest.Services/RemoteRepositoryFactory.cs
@@ -3,9 +3,16 @@ using LibGit2Sharp;
 
 namespace GitPullRequest.Services
 {
-    public static class GitRepositoryFactory
+    public class RemoteRepositoryFactory
     {
-        public static RemoteRepository Create(IGitService gitService, IRepository repo, string remoteName)
+        readonly IGitService gitService;
+
+        public RemoteRepositoryFactory(IGitService gitService = null)
+        {
+            this.gitService = gitService;
+        }
+
+        public RemoteRepository Create(IRepository repo, string remoteName)
         {
             var url = repo.Network.Remotes[remoteName].Url;
             if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))

--- a/GitPullRequest.Services/lib/Guard.cs
+++ b/GitPullRequest.Services/lib/Guard.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+
+namespace GitHub.Extensions
+{
+    public static class Guard
+    {
+        public static void ArgumentNotNull(object value, string name)
+        {
+            if (value != null) return;
+            string message = String.Format(CultureInfo.InvariantCulture, "Failed Null Check on '{0}'", name);
+            throw new ArgumentNullException(name, message);
+        }
+
+        public static void ArgumentNonNegative(int value, string name)
+        {
+            if (value > -1) return;
+
+            var message = String.Format(CultureInfo.InvariantCulture, "The value for '{0}' must be non-negative", name);
+            throw new ArgumentException(message, name);
+        }
+
+        /// <summary>
+        /// Checks a string argument to ensure it isn't null or empty.
+        /// </summary>
+        /// <param name = "value">The argument value to check.</param>
+        /// <param name = "name">The name of the argument.</param>
+        public static void ArgumentNotEmptyString(string value, string name)
+        {
+            if (value?.Length > 0) return;
+            string message = String.Format(CultureInfo.InvariantCulture, "The value for '{0}' must not be empty", name);
+            throw new ArgumentException(message, name);
+        }
+
+        public static void ArgumentInRange(int value, int minValue, string name)
+        {
+            if (value >= minValue) return;
+            string message = String.Format(CultureInfo.InvariantCulture,
+                "The value '{0}' for '{1}' must be greater than or equal to '{2}'",
+                value,
+                name,
+                minValue);
+            throw new ArgumentOutOfRangeException(name, message);
+        }
+
+        public static void ArgumentInRange(int value, int minValue, int maxValue, string name)
+        {
+            if (value >= minValue && value <= maxValue) return;
+            string message = String.Format(CultureInfo.InvariantCulture,
+                "The value '{0}' for '{1}' must be greater than or equal to '{2}' and less than or equal to '{3}'",
+                value,
+                name,
+                minValue,
+                maxValue);
+            throw new ArgumentOutOfRangeException(name, message);
+        }
+    }
+}

--- a/GitPullRequest.Services/lib/StringEquivalent.cs
+++ b/GitPullRequest.Services/lib/StringEquivalent.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace GitHub.Primitives
+{
+    [Serializable]
+    public abstract class StringEquivalent<T> : ISerializable, IXmlSerializable where T : StringEquivalent<T>
+    {
+        protected string Value;
+
+        protected StringEquivalent(string value)
+        {
+            Value = value;
+        }
+
+        protected StringEquivalent()
+        {
+        }
+
+        public abstract T Combine(string addition);
+
+        [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "Add doesn't make sense in the case of a string equivalent")]
+        public static T operator +(StringEquivalent<T> a, string b)
+        {
+            return a.Combine(b);
+        }
+
+        public static bool operator ==(StringEquivalent<T> a, StringEquivalent<T> b)
+        {
+            // If both are null, or both are same instance, return true.
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            // If one is null, but not both, return false.
+            if (((object)a == null) || ((object)b == null))
+            {
+                return false;
+            }
+
+            // Return true if the fields match:
+            return a.Value.Equals(b.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool operator !=(StringEquivalent<T> a, StringEquivalent<T> b)
+        {
+            return !(a == b);
+        }
+
+        public override bool Equals(Object obj)
+        {
+            return obj != null && Equals(obj as T) || Equals(obj as string);
+        }
+
+        public bool Equals(T stringEquivalent)
+        {
+            return this == stringEquivalent;
+        }
+
+        public override int GetHashCode()
+        {
+            return (Value ?? "").GetHashCode();
+        }
+
+        public virtual bool Equals(string other)
+        {
+            return other != null && Value == other;
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+
+        protected StringEquivalent(SerializationInfo info) : this(info.GetValue("Value", typeof(string)) as string)
+        {
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("Value", Value);
+        }
+
+        public XmlSchema GetSchema()
+        {
+            return null;
+        }
+
+        public void ReadXml(XmlReader reader)
+        {
+            Value = reader.ReadString();
+        }
+
+        public void WriteXml(XmlWriter writer)
+        {
+            writer.WriteString(Value);
+        }
+
+        public int Length
+        {
+            get { return Value != null ? Value.Length : 0; }
+        }
+    }
+}

--- a/GitPullRequest.Services/lib/StringExtensions.cs
+++ b/GitPullRequest.Services/lib/StringExtensions.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace GitHub.Extensions
+{
+    public static class StringExtensions
+    {
+        public static bool Contains(this string s, string expectedSubstring, StringComparison comparison)
+        {
+            Guard.ArgumentNotNull(s, nameof(s));
+            Guard.ArgumentNotNull(expectedSubstring, nameof(expectedSubstring));
+
+            return s.IndexOf(expectedSubstring, comparison) > -1;
+        }
+
+        public static bool ContainsAny(this string s, IEnumerable<char> characters)
+        {
+            Guard.ArgumentNotNull(s, nameof(s));
+
+            return s.IndexOfAny(characters.ToArray()) > -1;
+        }
+
+        public static string DebugRepresentation(this string s)
+        {
+            s = s ?? "(null)";
+            return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", s);
+        }
+
+        public static string ToNullIfEmpty(this string s)
+        {
+            return String.IsNullOrEmpty(s) ? null : s;
+        }
+
+        public static bool StartsWith(this string s, char c)
+        {
+            if (String.IsNullOrEmpty(s)) return false;
+            return s.First() == c;
+        }
+
+        public static string RightAfter(this string s, string search)
+        {
+            Guard.ArgumentNotNull(search, nameof(search));
+
+            if (s == null) return null;
+            int lastIndex = s.IndexOf(search, StringComparison.OrdinalIgnoreCase);
+            if (lastIndex < 0)
+                return null;
+
+            return s.Substring(lastIndex + search.Length);
+        }
+
+        public static string RightAfterLast(this string s, string search)
+        {
+            Guard.ArgumentNotNull(search, nameof(search));
+
+            if (s == null) return null;
+            int lastIndex = s.LastIndexOf(search, StringComparison.OrdinalIgnoreCase);
+            if (lastIndex < 0)
+                return null;
+
+            return s.Substring(lastIndex + search.Length);
+        }
+
+        public static string LeftBeforeLast(this string s, string search)
+        {
+            Guard.ArgumentNotNull(search, nameof(search));
+
+            if (s == null) return null;
+            int lastIndex = s.LastIndexOf(search, StringComparison.OrdinalIgnoreCase);
+            if (lastIndex < 0)
+                return null;
+
+            return s.Substring(0, lastIndex);
+        }
+
+        // Returns a file name even if the path is FUBAR.
+        public static string ParseFileName(this string path)
+        {
+            if (path == null) return null;
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).RightAfterLast(Path.DirectorySeparatorChar + "");
+        }
+
+        // Returns the parent directory even if the path is FUBAR.
+        public static string ParseParentDirectory(this string path)
+        {
+            if (path == null) return null;
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).LeftBeforeLast(Path.DirectorySeparatorChar + "");
+        }
+
+        public static string EnsureStartsWith(this string s, char c)
+        {
+            if (s == null) return null;
+            return c + s.TrimStart(c);
+        }
+
+        // Ensures the string ends with the specified character.
+        public static string EnsureEndsWith(this string s, char c)
+        {
+            if (s == null) return null;
+            return s.TrimEnd(c) + c;
+        }
+
+        public static string NormalizePath(this string path)
+        {
+            if (String.IsNullOrEmpty(path)) return null;
+
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        }
+
+        public static string TrimEnd(this string s, string suffix)
+        {
+            Guard.ArgumentNotNull(suffix, nameof(suffix));
+
+            if (s == null) return null;
+            if (!s.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                return s;
+
+            return s.Substring(0, s.Length - suffix.Length);
+        }
+
+        public static string RemoveSurroundingQuotes(this string s)
+        {
+            Guard.ArgumentNotNull(s, nameof(s));
+
+            if (s.Length < 2)
+                return s;
+
+            var quoteCharacters = new[] { '"', '\'' };
+            char firstCharacter = s[0];
+            if (!quoteCharacters.Contains(firstCharacter))
+                return s;
+
+            if (firstCharacter != s[s.Length - 1])
+                return s;
+
+            return s.Substring(1, s.Length - 2);
+        }
+
+        public static Int32 ToInt32(this string s)
+        {
+            Guard.ArgumentNotNull(s, nameof(s));
+
+            Int32 val;
+            return Int32.TryParse(s, out val) ? val : 0;
+        }
+
+        /// <summary>
+        /// Wrap a string to the specified length.
+        /// </summary>
+        /// <param name="text">The text string to wrap</param>
+        /// <param name="maxLength">The character length to wrap at</param>
+        /// <returns>A wrapped string using the platform's default newline character. This string will end in a newline.</returns>
+        public static string Wrap(this string text, int maxLength = 72)
+        {
+            Guard.ArgumentNotNull(text, nameof(text));
+
+            if (text.Length == 0) return string.Empty;
+
+            var sb = new StringBuilder();
+            foreach (var unwrappedLine in text.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
+            {
+                var line = new StringBuilder();
+                foreach (var word in unwrappedLine.Split(' '))
+                {
+                    var needsLeadingSpace = line.Length > 0;
+
+                    var extraLength = (needsLeadingSpace ? 1 : 0) + word.Length;
+                    if (line.Length + extraLength > maxLength)
+                    {
+                        sb.AppendLine(line.ToString());
+                        line.Clear();
+                        needsLeadingSpace = false;
+                    }
+
+                    if (needsLeadingSpace)
+                        line.Append(" ");
+
+                    line.Append(word);
+                }
+
+                sb.AppendLine(line.ToString());
+            }
+
+            return sb.ToString();
+        }
+
+        public static Uri ToUriSafe(this string url)
+        {
+            Guard.ArgumentNotNull(url, nameof(url));
+
+            Uri uri;
+            Uri.TryCreate(url, UriKind.Absolute, out uri);
+            return uri;
+        }
+
+        /// <summary>
+        /// Returns an alphanumeric sentence cased string with dashes and underscores as spaces.
+        /// </summary>
+        /// <param name="s">The string to format.</param>
+        [SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase")]
+        public static string Humanize(this string s)
+        {
+            if (String.IsNullOrWhiteSpace(s))
+            {
+                return s;
+            }
+
+            var matches = Regex.Matches(s, @"[a-zA-Z\d]{1,}", RegexOptions.None);
+
+            if (matches.Count == 0)
+            {
+                return s;
+            }
+
+            var result = matches.Cast<Match>().Select(match => match.Value.ToLower(CultureInfo.InvariantCulture));
+            var combined = String.Join(" ", result);
+            return Char.ToUpper(combined[0], CultureInfo.InvariantCulture) + combined.Substring(1);
+        }
+
+        /// <summary>
+        /// Generates a SHA256 hash for a string.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <returns>The SHA256 hash.</returns>
+        public static string GetSha256Hash(this string input)
+        {
+            Guard.ArgumentNotNull(input, nameof(input));
+
+            using (var sha256 = SHA256.Create())
+            {
+                var bytes = Encoding.UTF8.GetBytes(input);
+                var hash = sha256.ComputeHash(bytes);
+
+                return string.Join("", hash.Select(b => b.ToString("x2", CultureInfo.InvariantCulture)));
+            }
+        }
+    }
+}

--- a/GitPullRequest.Services/lib/UriExtensions.cs
+++ b/GitPullRequest.Services/lib/UriExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace GitHub.Extensions
+{
+    public static class UriExtensions
+    {
+        /// <summary>
+        /// Appends a relative path to the URL.
+        /// </summary>
+        /// <remarks>
+        /// The Uri constructor for combining relative URLs have a different behavior with URLs that end with /
+        /// than those that don't.
+        /// </remarks>
+        public static Uri Append(this Uri uri, string relativePath)
+        {
+            if (!uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal))
+            {
+                uri = new Uri(uri + "/");
+            }
+            return new Uri(uri, new Uri(relativePath, UriKind.Relative));
+        }
+
+        public static bool IsHypertextTransferProtocol(this Uri uri)
+        {
+            return uri.Scheme == "http" || uri.Scheme == "https";
+        }
+
+        public static bool IsSameHost(this Uri uri, Uri compareUri)
+        {
+            return uri.Host.Equals(compareUri.Host, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/GitPullRequest.Services/lib/UriString.cs
+++ b/GitPullRequest.Services/lib/UriString.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+using GitHub.Extensions;
+
+namespace GitHub.Primitives
+{
+    /// <summary>
+    /// This class represents a URI given to us as a string and is implicitly 
+    /// convertible to and from string.
+    /// </summary>
+    /// <remarks>
+    /// This typically represents a URI from an external source such as user input, a 
+    /// Git Repo Remote, or an API URL.  We try to preserve the original form and let 
+    /// downstream clients validate the URL. This class doesn't validate the URL. It just 
+    /// performs a best-effort to parse the URI into bits important to us. For example, 
+    /// we need to know the HOST so we can compare against GitHub.com, GH:E instances, etc.
+    /// </remarks>
+    [SuppressMessage("Microsoft.Usage", "CA2240:ImplementISerializableCorrectly", Justification = "GetObjectData is implemented in the base class")]
+    [Serializable]
+    [TypeConverter(typeof(UriStringConverter))]
+    public class UriString : StringEquivalent<UriString>, IEquatable<UriString>
+    {
+        static readonly Regex sshRegex = new Regex(@"^.+@(?<host>(\[.*?\]|[a-z0-9-.]+?))(:(?<owner>.*?))?(/(?<repo>.*)(\.git)?)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        readonly Uri url;
+
+        public UriString(string uriString) : base(NormalizePath(uriString))
+        {
+            if (uriString == null || uriString.Length == 0) return;
+            if (Uri.TryCreate(uriString, UriKind.Absolute, out url))
+            {
+                if (!url.IsFile)
+                    SetUri(url);
+                else
+                    SetFilePath(url);
+            }
+            else if (!ParseScpSyntax(uriString))
+            {
+                SetFilePath(uriString);
+            }
+
+            if (Owner != null && RepositoryName != null)
+            {
+                NameWithOwner = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", Owner, RepositoryName);
+            }
+            else if (Owner != null)
+            {
+                NameWithOwner = Owner;
+            }
+            else if (RepositoryName != null)
+            {
+                NameWithOwner = RepositoryName;
+            }
+        }
+
+        public static UriString ToUriString(Uri uri)
+        {
+            return uri == null ? null : new UriString(uri.ToString());
+        }
+
+        public Uri ToUri()
+        {
+            if (url == null)
+                throw new InvalidOperationException("This Uri String is not a valid Uri");
+            return url;
+        }
+
+        void SetUri(Uri uri)
+        {
+            var ownerSegment = FindSegment(uri.Segments, 0);
+            var repositorySegment = FindSegment(uri.Segments, 1);
+
+            Host = uri.Host;
+            Owner = ownerSegment;
+            RepositoryName = GetRepositoryName(repositorySegment);
+            IsHypertextTransferProtocol = uri.IsHypertextTransferProtocol();
+
+            string FindSegment(string[] segments, int number)
+                => segments.Skip(number + 1).FirstOrDefault()?.TrimEnd("/");
+        }
+
+        void SetFilePath(Uri uri)
+        {
+            Host = "";
+            Owner = "";
+            RepositoryName = GetRepositoryName(uri.Segments.Last());
+            IsFileUri = true;
+        }
+
+        void SetFilePath(string path)
+        {
+            Host = "";
+            Owner = "";
+            RepositoryName = GetRepositoryName(path.Replace("/", @"\").RightAfterLast(@"\"));
+            IsFileUri = true;
+        }
+
+        // For xml serialization
+        protected UriString()
+        {
+        }
+
+        bool ParseScpSyntax(string scpString)
+        {
+            var match = sshRegex.Match(scpString);
+            if (match.Success)
+            {
+                Host = match.Groups["host"].Value.ToNullIfEmpty();
+                Owner = match.Groups["owner"].Value.ToNullIfEmpty();
+                RepositoryName = GetRepositoryName(match.Groups["repo"].Value);
+                IsScpUri = true;
+                return true;
+            }
+            return false;
+        }
+
+        public string Host { get; private set; }
+
+        public string Owner { get; private set; }
+
+        public string RepositoryName { get; private set; }
+
+        public string NameWithOwner { get; private set; }
+
+        public bool IsFileUri { get; private set; }
+
+        public bool IsScpUri { get; private set; }
+
+        public bool IsValidUri => url != null;
+
+        /// <summary>
+        /// Attempts a best-effort to convert the remote origin to a GitHub Repository URL,
+        /// optionally changing the owner.
+        /// </summary>
+        /// <param name="owner">The owner to use, if null uses <see cref="Owner"/>.</param>
+        /// <returns>A converted uri, or the existing one if we can't convert it (which might be null)</returns>
+        public Uri ToRepositoryUrl(string owner = null)
+        {
+            // we only want to process urls that represent network resources
+            if (!IsScpUri && (!IsValidUri || IsFileUri)) return url;
+
+            var scheme = url != null && IsHypertextTransferProtocol
+                ? url.Scheme
+                : Uri.UriSchemeHttps;
+
+            var nameWithOwner = owner != null && RepositoryName != null ?
+                string.Format(CultureInfo.InvariantCulture, "{0}/{1}", owner, RepositoryName) :
+                NameWithOwner;
+
+            return new UriBuilder
+            {
+                Scheme = scheme,
+                Host = Host,
+                Path = nameWithOwner,
+                Port = url?.Port == 80
+                    ? -1
+                    : (url?.Port ?? -1)
+            }.Uri;
+        }
+
+        /// <summary>
+        /// True if the URL is HTTP or HTTPS
+        /// </summary>
+        public bool IsHypertextTransferProtocol { get; private set; }
+
+        [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates")]
+        public static implicit operator UriString(string value)
+        {
+            if (value == null) return null;
+
+            return new UriString(value);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates")]
+        public static implicit operator string(UriString uriString)
+        {
+            return uriString?.Value;
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA2234:PassSystemUriObjectsInsteadOfStrings", Justification = "No.")]
+        public override UriString Combine(string addition)
+        {
+            if (url != null)
+            {
+                var urlBuilder = new UriBuilder(url);
+                if (!String.IsNullOrEmpty(urlBuilder.Query))
+                {
+                    var query = urlBuilder.Query;
+                    if (query.StartsWith("?", StringComparison.Ordinal))
+                    {
+                        query = query.Substring(1);
+                    }
+
+                    if (!addition.StartsWith("&", StringComparison.Ordinal) && query.Length > 0)
+                    {
+                        addition = "&" + addition;
+                    }
+                    urlBuilder.Query = query + addition;
+                }
+                else
+                {
+                    var path = url.AbsolutePath;
+                    if (path == "/") path = "";
+                    if (!addition.StartsWith("/", StringComparison.Ordinal)) addition = "/" + addition;
+
+                    urlBuilder.Path = path + addition;
+                }
+                return ToUriString(urlBuilder.Uri);
+            }
+            return String.Concat(Value, addition);
+        }
+
+        /// <summary>
+        /// Compare repository URLs ignoring any trailing ".git" or difference in case.
+        /// </summary>
+        /// <returns>True if URLs reference the same repository.</returns>
+        public static bool RepositoryUrlsAreEqual(UriString uri1, UriString uri2)
+        {
+            if (!uri1.IsHypertextTransferProtocol || !uri2.IsHypertextTransferProtocol)
+            {
+                // Not a repository URL
+                return false;
+            }
+
+            // Normalize repository URLs
+            var str1 = uri1.ToRepositoryUrl().ToString();
+            var str2 = uri2.ToRepositoryUrl().ToString();
+            return string.Equals(str1, str2, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override string ToString()
+        {
+            // Makes this look better in the debugger.
+            return Value;
+        }
+
+        /// <summary>
+        /// Makes a copy of the URI with the specified owner.
+        /// </summary>
+        /// <param name="owner">The owner.</param>
+        /// <returns>A new <see cref="UriString"/>.</returns>
+        public UriString WithOwner(string owner) => ToUriString(ToRepositoryUrl(owner));
+
+        protected UriString(SerializationInfo info, StreamingContext context)
+            : this(GetSerializedValue(info))
+        {
+        }
+
+        static string GetSerializedValue(SerializationInfo info)
+        {
+            // First try to get the current way it's serialized, then fall back to the older way it's serialized.
+            string value;
+            try
+            {
+                value = info.GetValue("Value", typeof(string)) as string;
+            }
+            catch (SerializationException)
+            {
+                value = info.GetValue("uriString", typeof(string)) as string;
+            }
+
+            return value;
+        }
+
+        static string NormalizePath(string path)
+        {
+            return path?.Replace('\\', '/');
+        }
+
+        static string GetRepositoryName(string repositoryNameSegment)
+        {
+            if (String.IsNullOrEmpty(repositoryNameSegment)
+                || repositoryNameSegment.Equals("/", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return repositoryNameSegment.TrimEnd('/').TrimEnd(".git");
+        }
+
+        bool IEquatable<UriString>.Equals(UriString other)
+        {
+            return other != null && Equals(ToString(), other.ToString());
+        }
+    }
+}

--- a/GitPullRequest.Services/lib/UriStringConverter.cs
+++ b/GitPullRequest.Services/lib/UriStringConverter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace GitHub.Primitives
+{
+    public class UriStringConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => sourceType == typeof(string);
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => new UriString((string)value);
+    }
+}

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -44,13 +44,14 @@ namespace GitPullRequest
                 return;
             }
 
+            Action<Exception> exceptionLogger = e => Console.WriteLine(e);
             var factory = new RemoteRepositoryFactory(new LibGitService(), new ShellGitService(), Shell);
             var service = new GitPullRequestService(factory);
             using (var repo = new Repository(repoPath))
             {
                 if (Prune)
                 {
-                    PruneBranches(service, repo);
+                    PruneBranches(service, repo, exceptionLogger);
                     return;
                 }
 
@@ -58,11 +59,11 @@ namespace GitPullRequest
                 {
                     if (List || Remote != null)
                     {
-                        ListBranches(service, repo, Remote);
+                        ListBranches(service, repo, Remote, exceptionLogger);
                         return;
                     }
 
-                    BrowsePullRequest(service, repo);
+                    BrowsePullRequest(service, repo, exceptionLogger);
                 }
                 catch (LibGit2SharpException e)
                 {
@@ -72,9 +73,9 @@ namespace GitPullRequest
             }
         }
 
-        void BrowsePullRequest(GitPullRequestService service, Repository repo)
+        void BrowsePullRequest(GitPullRequestService service, Repository repo, Action<Exception> exceptionLogger)
         {
-            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo);
+            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo, exceptionLogger);
             var upstreamRepositoires = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
 
             var prs = (PullRequestNumber == 0 ? service.FindPullRequests(remoteRepositoryCache, upstreamRepositoires, repo.Head) :
@@ -112,9 +113,9 @@ namespace GitPullRequest
             Console.WriteLine("Couldn't find pull request or remote branch");
         }
 
-        void ListBranches(GitPullRequestService service, Repository repo, string remoteName)
+        void ListBranches(GitPullRequestService service, Repository repo, string remoteName, Action<Exception> exceptionLogger)
         {
-            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo);
+            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo, exceptionLogger);
             var upstreamRepositoires = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
 
             var prs = repo.Branches
@@ -162,9 +163,9 @@ namespace GitPullRequest
             }
         }
 
-        void PruneBranches(GitPullRequestService service, Repository repo)
+        void PruneBranches(GitPullRequestService service, Repository repo, Action<Exception> exceptionLogger)
         {
-            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo);
+            var remoteRepositoryCache = service.GetRemoteRepositoryCache(repo, exceptionLogger);
             var upstreamRepositoires = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
 
             var prs = repo.Branches
@@ -200,7 +201,8 @@ namespace GitPullRequest
         {
             // Only consider one repository per URL and prioritize ones with a remote named "origin"
             return repo.Network.Remotes
-                .Select(r => remoteRepositoryCache[r.Name])
+                .Select(r => remoteRepositoryCache.FindRemoteRepository(r.Name))
+                .Where(r => r != null)
                 .GroupBy(r => r.Url)
                 .Select(g => g
                     .OrderBy(r => r.RemoteName == "origin" ? 0 : 1)

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -44,8 +44,7 @@ namespace GitPullRequest
                 return;
             }
 
-            var gitService = Shell ? new ShellGitService() : new LibGitService() as IGitService;
-            var factory = new RemoteRepositoryFactory(gitService);
+            var factory = new RemoteRepositoryFactory(new LibGitService(), new ShellGitService(), Shell);
             var service = new GitPullRequestService(factory);
             using (var repo = new Repository(repoPath))
             {

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -45,7 +45,8 @@ namespace GitPullRequest
             }
 
             var gitService = Shell ? new ShellGitService() : new LibGitService() as IGitService;
-            var service = new GitPullRequestService(gitService);
+            var factory = new RemoteRepositoryFactory(gitService);
+            var service = new GitPullRequestService(factory);
             using (var repo = new Repository(repoPath))
             {
                 if (Prune)


### PR DESCRIPTION
I've been using this alongside the [hub](https://github.com/github/hub) git extension which uses SSH by default. When creating a new remote, it would use `git@github.com:user/repo.git` style URLs (which `git-pr` and `System.Uri` doesn't recognize.

I've used the `GitHub.Primitives.UriString` class from GitHub for Visual Studio, which was mostly developed for parsing git remote URIs. This is maybe overkill, but it works.

### Notes on GitHub URIs

For example:
git@github.com:user/repo.git

Here is a summary of different URL types:
https://gist.github.com/grawity/4392747

### Notes on Azure DevOps URIs

Example URLs:
`jcansdale@vs-ssh.visualstudio.com:v3/jcansdale/git-pr/git-pr`
`https://<organization>@dev.azure.com/<organization>/<project>/_git/<repo>`

Depends on #38 