### PR TITLE
Survive a branch Tip being null

### DIFF
--- a/GitPullRequest.Services.Tests/GitPullRequest.Services.Tests.csproj
+++ b/GitPullRequest.Services.Tests/GitPullRequest.Services.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.0.0-rc1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -122,7 +122,7 @@ public class GitPullRequestServiceTests
     {
         var gitService = new LibGitService();
         var factory = new RemoteRepositoryFactory(gitService);
-        return new GitPullRequestService(factory);
+        return new GitPullRequestService(factory, s => { });
     }
 
     static IRepository CreateRepository(

--- a/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
+++ b/GitPullRequest.Services.Tests/GitPullRequestServiceTests.cs
@@ -48,6 +48,21 @@ public class GitPullRequestServiceTests
             Assert.That(prs, Is.Empty);
         }
 
+        [Test]
+        public void Branch_Tip_Null_No_Pull_Request()
+        {
+            var repo = CreateRepository("sha", null, null, Array.Empty<Remote>());
+            var target = CreateGitPullRequestService();
+            var remoteRepositoryCache = target.GetRemoteRepositoryCache(repo, e => { });
+            var upstreamRepositories = CreateUpstreamRepositoires(remoteRepositoryCache, repo);
+            var branch = Substitute.For<Branch>();
+            branch.Tip.Returns(null as Commit);
+
+            var prs = target.FindPullRequests(remoteRepositoryCache, upstreamRepositories, branch);
+
+            Assert.That(prs, Is.Empty);
+        }
+
         [TestCase("headSha", "prSha")]
         [TestCase("sameHeadAndPrSha", "sameHeadAndPrSha")]
         public void Live_Pull_Request(string headSha, string prSha)

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -7,11 +7,13 @@ namespace GitPullRequest.Services
 {
     public class GitPullRequestService
     {
+        readonly Action<string> warningLogger;
         readonly RemoteRepositoryFactory remoteRepositoryFactory;
 
-        public GitPullRequestService(RemoteRepositoryFactory remoteRepositoryFactory)
+        public GitPullRequestService(RemoteRepositoryFactory remoteRepositoryFactory, Action<string> warningLogger)
         {
             this.remoteRepositoryFactory = remoteRepositoryFactory;
+            this.warningLogger = warningLogger;
         }
 
         public RemoteRepositoryCache GetRemoteRepositoryCache(IRepository repo, Action<Exception> exceptionLogger)
@@ -41,6 +43,7 @@ namespace GitPullRequest.Services
                 var tip = branch.Tip;
                 if (tip == null)
                 {
+                    warningLogger?.Invoke($"Tip of branch {branch.CanonicalName} was null");
                     return Array.Empty<(RemoteRepository, int, bool)>();
                 }
 

--- a/GitPullRequest.Services/GitPullRequestService.cs
+++ b/GitPullRequest.Services/GitPullRequestService.cs
@@ -38,7 +38,13 @@ namespace GitPullRequest.Services
 
             if (sha == null)
             {
-                sha = branch.Tip.Sha;
+                var tip = branch.Tip;
+                if (tip == null)
+                {
+                    return Array.Empty<(RemoteRepository, int, bool)>();
+                }
+
+                sha = tip.Sha;
             }
 
             return FindPullRequestsForSha(remoteRepositoryCache, upstreamRepositories, sha)

--- a/GitPullRequest/Program.cs
+++ b/GitPullRequest/Program.cs
@@ -45,9 +45,10 @@ namespace GitPullRequest
             }
 
             Action<Exception> exceptionLogger = e => Console.WriteLine(e);
+            Action<string> warningLogger = s => Console.WriteLine($"WARNING: {s}");
             var gitService = new DynamicGitService(new LibGitService(), new ShellGitService(), Shell);
             var factory = new RemoteRepositoryFactory(gitService);
-            var service = new GitPullRequestService(factory);
+            var service = new GitPullRequestService(factory, warningLogger);
             using (var repo = new Repository(repoPath))
             {
                 if (Prune)


### PR DESCRIPTION
Not sure when/why this happens, but a branch Tip can be null.

Fixes #34